### PR TITLE
Load the widgets accordingly to the filters

### DIFF
--- a/app/assets/javascripts/pages/data_portal/DataPortalCountryPage.js
+++ b/app/assets/javascripts/pages/data_portal/DataPortalCountryPage.js
@@ -220,9 +220,20 @@
       this.widgetsContainer.innerHTML = ''; // We ensure it's empty first
       this.widgetsContainer.appendChild(fragment);
 
+      // If the widget instances already exist, we remove the listeners
+      // and reset their pointer
+      if (this.widgets) {
+        this.widgets.forEach(function (widget) {
+          this.stopListening(widget);
+        }, this);
+        this.widgets = [];
+      } else {
+        this.widgets = [];
+      }
+
       // We instantiate the widget views
       collection.forEach(function (indicator, index) {
-        var chart = new App.View.ChartWidgetView({
+        var widget = new App.View.ChartWidgetView({
           el: this.widgetsContainer.children[index].children[0],
           id: indicator.indicator,
           iso: this.options.iso,
@@ -230,7 +241,9 @@
           filters: this.options._filters
         });
 
-        this.listenTo(chart, 'data:sync', this._onWidgetSync);
+        this.widgets.push(widget);
+
+        this.listenTo(widget, 'data:sync', this._onWidgetSync);
       }, this);
     }
 

--- a/app/assets/javascripts/views/data_portal/ChartWidgetView.js
+++ b/app/assets/javascripts/views/data_portal/ChartWidgetView.js
@@ -157,19 +157,19 @@
     _fetchData: function () {
       this.model.fetch()
         .done(function () {
-          var data = this.model.toJSON().data;
+          var data = this.model.get('data');
           if (data.length) this.widgetToolbox = new App.Helper.WidgetToolbox(data);
 
           // If the indicator doesn't have any data, we also want to send an event
           // to notify the parent view about it
           this.trigger('data:sync', {
-            name: this.model.toJSON().title,
+            name: this.model.get('title'),
             data: data
           });
 
           // We pre-render the component with its template
           this.el.innerHTML = this.template({
-            name: this.model.toJSON().title,
+            name: this.model.get('title'),
             noData: !data.length
           });
           this.chartContainer = this.el.querySelector('.js-chart');
@@ -248,7 +248,7 @@
     _generateVegaSpec: function () {
       if (!this.options.chart) {
         // If no data, we render the dedicated chart
-        if (!this.model.toJSON().data.length) {
+        if (!this.model.get('data').length) {
           this.options.chart = 'empty';
         } else {
           var availableCharts = this.widgetToolbox.getAvailableCharts();
@@ -265,7 +265,7 @@
       var chartDimensions = this._computeChartDimensions();
 
       return this._getChartTemplate()({
-        data: JSON.stringify(this.model.toJSON().data),
+        data: JSON.stringify(this.model.get('data')),
         width: chartDimensions.width,
         height: chartDimensions.height
       });


### PR DESCRIPTION
This PR takes care of sending the information about the indicators to the filters modal and to re-render the widgets whenever they change.

The filters modal will receive two parameters at instantiation:
- `this.options._indicatorsData` which is the list of indicators with their available options
- `this._onFiltersUpdate` as a callback when the user is done applying filters; it takes as argument the list of applied filters, for example:
```
[
  { name: 'gender', options: ['Female'] },
  { name: 'i2i_Education', options: ['Primary education', 'Secondary education'] }
]
```
means that the user selected `Female`, `Primary education` and `Secondary education` as filters.

Let me know @andresgnlez if that sounds right.