### PR TITLE
Adjusts picture card to content, not card height

### DIFF
--- a/app/assets/stylesheets/_settings.scss
+++ b/app/assets/stylesheets/_settings.scss
@@ -29,6 +29,10 @@ $color-7: #f2f3f4;
 $body-max-width: 1280px;
 $content-max-width: 1060px;
 
+// cards
+$card-height: 325px;
+$card-bottom-margin: 20px;
+
 // grid
 $grid-columns: 12;
 $grid-max-width: 1080px;

--- a/app/assets/stylesheets/components/shared/c-card-highlight.scss
+++ b/app/assets/stylesheets/components/shared/c-card-highlight.scss
@@ -13,6 +13,7 @@
   &.-homepage {
     display: block;
     max-width: 525px;
+    height: 100%;
     margin: 0 auto;
     padding: 20px 0 40px;
     background: transparent;

--- a/app/assets/stylesheets/components/shared/c-card.scss
+++ b/app/assets/stylesheets/components/shared/c-card.scss
@@ -1,14 +1,18 @@
 
 .c-card {
+  display: flex;
   position: relative;
-  margin: 0 0 20px;
+  flex-direction: column;
+  height: $card-height;
+  margin: 0 0 $card-bottom-margin;
 
   background: $color-4;
   box-shadow: 0 2px 3px 0 rgba($color-6, .15);
 
   > .picture {
+    display: flex;
     width: 100%;
-    height: 325px;
+    height: 100%;
 
     background-color: $color-1;
     background-repeat: no-repeat;
@@ -17,15 +21,15 @@
 
     > a {
       display: inline-block;
+      position: absolute;
+      top: 0;
+      left: 0;
       width: 100%;
       height: 100%;
     }
   }
 
   .metadata {
-    position: absolute;
-    bottom: 0;
-    left: 0;
     width: 100%;
     padding: 30px;
     background-color: $color-4;
@@ -60,47 +64,24 @@
     }
   }
 
-  &.-small {
-    display: flex;
-    flex-direction: column;
-  }
-
-  &.-medium {
-    display: flex;
-    flex-direction: column;
-  }
-
-  &.-big {
-    display: flex;
-    flex-direction: column;
-  }
-
   &.-horizontal {
-    > .picture {
-      height: 100%px;
-    }
+    flex-direction: column;
 
     @media #{$mq-tablet} {
-      display: flex;
+      flex-direction: row;
       height: 280px;
 
       > .picture {
+        width: 50%;
         height: 100%;
       }
 
       > .metadata {
-        top: 0;
-        right: 0;
-        bottom: 0;
-        left: auto;
         width: 50%;
       }
 
       &.-reverse {
-        > .metadata {
-          right: auto;
-          left: 0;
-        }
+        flex-direction: row-reverse;
       }
     }
 
@@ -112,14 +93,16 @@
   &.-highlighted {
 
     @media #{$mq-laptop} {
-      position: relative;
-      height: calc(325px * 2 + 20px);
+      height: calc(#{$card-height} * 2 + #{$card-bottom-margin});
 
       > .picture {
         height: 100%;
       }
 
       > .metadata {
+        position: absolute;
+        bottom: 0;
+        left: 0;
         max-width: 340px;
       }
     }

--- a/app/views/data_portal/index.html.erb
+++ b/app/views/data_portal/index.html.erb
@@ -67,7 +67,7 @@
       <div class="l-card-grid">
         <div class="row">
           <div class="grid-s-12 grid-m-6 grid-l-3">
-            <article class="c-card -medium">
+            <article class="c-card">
               <div class="picture" style="background-image: url(images/placeholders/placeholder_1.jpg)">
                 <a href="#"></a>
               </div>
@@ -79,7 +79,7 @@
             </article>
           </div>
           <div class="grid-s-12 grid-m-6 grid-l-3">
-            <article class="c-card -medium">
+            <article class="c-card">
               <div class="picture" style="background-image: url(images/placeholders/placeholder_1.jpg)">
                 <a href="#"></a>
               </div>
@@ -91,7 +91,7 @@
             </article>
           </div>
           <div class="grid-s-12 grid-m-6 grid-l-3">
-            <article class="c-card -medium">
+            <article class="c-card">
               <div class="picture" style="background-image: url(images/placeholders/placeholder_1.jpg)">
                 <a href="#"></a>
               </div>
@@ -103,7 +103,7 @@
             </article>
           </div>
           <div class="grid-s-12 grid-m-6 grid-l-3">
-            <article class="c-card -medium">
+            <article class="c-card">
               <div class="picture" style="background-image: url(images/placeholders/placeholder_1.jpg)">
                 <a href="#"></a>
               </div>

--- a/app/views/libraries/index.html.erb
+++ b/app/views/libraries/index.html.erb
@@ -39,7 +39,7 @@
           <div class="grid-s-12 grid-m-6 grid-l-4 grid-xl-3 js-card"
             data-type="<%= LibraryType.key_for(library.content_type.to_i) if library.content_type.is_a? String %>"
           >
-            <article class="c-card -small">
+            <article class="c-card">
               <div class="picture" style="background-image: url(<%= library.image %>)"></div>
               <div class="metadata">
                 <h4 class="title -xs -dark"><%= library.title %></h4>

--- a/app/views/updates/events/index.html.erb
+++ b/app/views/updates/events/index.html.erb
@@ -28,7 +28,7 @@
         <div class="row">
           <% @events.each do |event| %>
             <div class="grid-s-12 grid-m-6 grid-l-3">
-              <article class="c-card -medium">
+              <article class="c-card">
                 <div class="picture" style="background-image: url(<%= event.image %>)">
                   <%= link_to '', updates_event_path(event.id) %>
                 </div>

--- a/app/views/updates/index.html.erb
+++ b/app/views/updates/index.html.erb
@@ -40,7 +40,7 @@
               </div>
             <% else %>
               <div class="grid-s-12 grid-m-6 grid-l-4">
-                <article class="c-card -medium">
+                <article class="c-card">
                   <div class="picture" style="background-image: url(<%= news.image %>)">
                     <%= link_to '', news_path(news.id) %>
                   </div>
@@ -69,7 +69,7 @@
           <div class="row">
             <% @events.each do |event| %>
               <div class="grid-s-12 grid-m-6 grid-l-4 grid-xl-3">
-                <article class="c-card -small">
+                <article class="c-card">
                   <div class="picture" style="background-image: url(<%= event.image %>)">
                     <%= link_to '', updates_event_path(event.id) %>
                   </div>

--- a/app/views/updates/news/index.html.erb
+++ b/app/views/updates/news/index.html.erb
@@ -44,7 +44,7 @@
               </div>
             <% else %>
               <div class="grid-s-12 grid-m-6 grid-l-4">
-                <article class="c-card -medium">
+                <article class="c-card">
                   <div class="picture" style="background-image: url(<%= news.image %>)">
                     <%= link_to '', news_path(news.id) %>
                   </div>


### PR DESCRIPTION
This PR adjusts the picture card to metadata data content (title and summary) instead of card height  and it was setted before. This way the picture adjust itself better depending on how the metadata content grows.

This change was asked by Dani. There's no Pivotal task related with this.