### PR TITLE
Sorts posts/news/event/libraries by update date

### DIFF
--- a/app/controllers/libraries_controller.rb
+++ b/app/controllers/libraries_controller.rb
@@ -4,7 +4,7 @@ class LibrariesController < ApplicationController
   # GET /libraries
   # GET /libraries.json
   def index
-    @libraries = Library.all
+    @libraries = Library.all.order(updated_at: :DESC)
   end
 
   # GET /libraries/1

--- a/app/controllers/updates/blogs_controller.rb
+++ b/app/controllers/updates/blogs_controller.rb
@@ -4,7 +4,7 @@ class Updates::BlogsController < ApplicationController
   # GET /blogs
   # GET /blogs.json
   def index
-    @blogs = Blog.limit(8).order(created_at: :DESC)
+    @blogs = Blog.limit(8).order(updated_at: :DESC)
   end
 
   # GET /blog/1

--- a/app/controllers/updates/events_controller.rb
+++ b/app/controllers/updates/events_controller.rb
@@ -4,7 +4,7 @@ class Updates::EventsController < ApplicationController
   # GET /events
   # GET /events.json
   def index
-    @events = Event.limit(16).order(created_at: :DESC)
+    @events = Event.limit(16).order(updated_at: :DESC)
   end
 
   # GET /event/1

--- a/app/controllers/updates/news_controller.rb
+++ b/app/controllers/updates/news_controller.rb
@@ -4,7 +4,7 @@ class Updates::NewsController < ApplicationController
   # GET /news
   # GET /news.json
   def index
-    @news = News.limit(15).order(created_at: :DESC)
+    @news = News.limit(15).order(updated_at: :DESC)
   end
 
   # GET /news/1

--- a/app/controllers/updates_controller.rb
+++ b/app/controllers/updates_controller.rb
@@ -1,8 +1,8 @@
 class UpdatesController < ApplicationController
 
   def index
-    @posts = Blog.limit(4).order(created_at: :DESC)
-    @news = News.limit(6).order(created_at: :DESC)
-    @events = Event.limit(4).order(created_at: :DESC)
+    @posts = Blog.limit(4).order(updated_at: :DESC)
+    @news = News.limit(6).order(updated_at: :DESC)
+    @events = Event.limit(4).order(updated_at: :DESC)
   end
 end


### PR DESCRIPTION
Pivotal task: https://www.pivotaltracker.com/story/show/141581907

This PR sorts posts/events/news and libraries by update date instead of creation date, like before.