### PR TITLE
Feature/restore filters

### DIFF
--- a/app/assets/javascripts/helpers/indicators.js
+++ b/app/assets/javascripts/helpers/indicators.js
@@ -1,0 +1,9 @@
+((function (App) {
+  App.Helper.Indicators = {
+    // List of the categories of indicators
+    CATEGORIES: {
+      COMMON: 'Common Indicators',
+      STRAND: 'Financial Access'
+    }
+  };
+})(this.App));

--- a/app/assets/javascripts/pages/data_portal/DataPortalCountryPage.js
+++ b/app/assets/javascripts/pages/data_portal/DataPortalCountryPage.js
@@ -97,8 +97,7 @@
      * @param {{ id: string, name: string, data: object[] }} event
      */
     _onWidgetSync: function (event) {
-      this._updateIndicatorsData(event.id, event.name, event.data);
-      this._updateWidgetContainer(event.id, event.data);
+      this._updateWidgetContainer(event.id);
     },
 
     /**
@@ -110,17 +109,6 @@
       if (visibleIndicators) this._updateVisibleIndicators(visibleIndicators);
       if (filters) this._updateFilters(filters);
       this._renderWidgets();
-    },
-
-    /**
-     * Update the indicators collection with the data passed as argument
-     * @param {string} indicatorId
-     * @param {string} indicatorName
-     * @param {object[]} data
-     */
-    _updateIndicatorsData: function (indicatorId, indicatorName, data) {
-      var indicator = this.indicatorsCollection.find({ id: indicatorId });
-      indicator.set({ options: data.map(function (option) { return option.label; }) });
     },
 
     /**
@@ -225,9 +213,8 @@
      * Update the size of the widget container depending on
      * if the category of the indicator
      * @param {string} indicatorId
-     * @param {object[]} data
      */
-    _updateWidgetContainer: function (indicatorId, data) {
+    _updateWidgetContainer: function (indicatorId) {
       var visibleIndicators = this._getVisibleIndicators();
       var index = _.findIndex(visibleIndicators, { id: indicatorId });
       var indicator = visibleIndicators[index];

--- a/app/assets/javascripts/pages/data_portal/DataPortalCountryPage.js
+++ b/app/assets/javascripts/pages/data_portal/DataPortalCountryPage.js
@@ -39,7 +39,8 @@
 
   // This object is used to detect the category of the indicators without having to repeat
   // the exact name
-  // NOTE: this object is duplicated in ChartWidgetView; make sure to update both of them
+  // NOTE: this object is duplicated in ChartWidgetView and ApplyFiltersView; make sure to
+  // update both of them
   var CATEGORIES = {
     COMMON: 'Common Indicators',
     STRAND: 'Financial Access'

--- a/app/assets/javascripts/pages/data_portal/DataPortalCountryPage.js
+++ b/app/assets/javascripts/pages/data_portal/DataPortalCountryPage.js
@@ -165,6 +165,8 @@
 
     _openFilterModal: function () {
       new App.View.FilterIndicatorsModal({
+        iso: this.options.iso,
+        year: this.options.year,
         indicators: this.indicatorsCollection.toJSON(),
         filters: this.options._filters,
         continueCallback: this._onFiltersUpdate.bind(this)

--- a/app/assets/javascripts/pages/data_portal/DataPortalCountryPage.js
+++ b/app/assets/javascripts/pages/data_portal/DataPortalCountryPage.js
@@ -37,15 +37,6 @@
     { id: 'insurance_strand', name: 'Insurance', category: 'Financial Access', visible: false }
   ];
 
-  // This object is used to detect the category of the indicators without having to repeat
-  // the exact name
-  // NOTE: this object is duplicated in ChartWidgetView and ApplyFiltersView; make sure to
-  // update both of them
-  var CATEGORIES = {
-    COMMON: 'Common Indicators',
-    STRAND: 'Financial Access'
-  };
-
   // This will be removed when we have a way to get the country name from the API
   var COUNTRIES = {
     UGA: 'Uganda',
@@ -218,7 +209,7 @@
       var visibleIndicators = this._getVisibleIndicators();
       var index = _.findIndex(visibleIndicators, { id: indicatorId });
       var indicator = visibleIndicators[index];
-      var isStrand = indicator.category === CATEGORIES.STRAND;
+      var isStrand = indicator.category === App.Helper.Indicators.CATEGORIES.STRAND;
 
       if (isStrand) {
         this.widgetsContainer.children[index].classList.remove('grid-l-6');
@@ -234,8 +225,10 @@
       return this.indicatorsCollection.toJSON().filter(function (indicator) {
         return indicator.visible;
       }).sort(function (a, b) {
-        if (a.category === CATEGORIES.STRAND && b.category !== CATEGORIES.STRAND) return -1;
-        if (a.category !== CATEGORIES.STRAND && b.category === CATEGORIES.STRAND) return 1;
+        var aIsStrand = a.category === App.Helper.Indicators.CATEGORIES.STRAND;
+        var bIsStrand = b.category === App.Helper.Indicators.CATEGORIES.STRAND;
+        if (aIsStrand && !bIsStrand) return -1;
+        if (!aIsStrand && bIsStrand) return 1;
         return 0;
       });
     },

--- a/app/assets/javascripts/templates/data_portal/filters.jst.ejs
+++ b/app/assets/javascripts/templates/data_portal/filters.jst.ejs
@@ -1,4 +1,4 @@
 <div class="c-modal-filters">
   <div class="filters-tabs js-tabs"></div>
-  <div class="js-filters-container"></div>
+  <div class="filters-container js-filters-container"></div>
 </div>

--- a/app/assets/javascripts/templates/data_portal/filters/apply-filters.jst.ejs
+++ b/app/assets/javascripts/templates/data_portal/filters/apply-filters.jst.ejs
@@ -8,9 +8,7 @@
             <% ind.options.forEach(function(opt) { %>
               <li class="indicator-filters-item">
                 <div class="c-checkbox">
-                  <input type="checkbox" <% if(opt.filtered) { %> checked <% } %> name="<%= ind.id %>"
-                    value="<%= opt.name %>" id="<%= opt.name %>"
-                  >
+                  <input type="checkbox" <% if(opt.filtered) { %> checked <% } %> value="<%= opt.name %>" id="<%= opt.name %>" class="js-option" data-indicator="<%= ind.id %>">
                   <label for="<%= opt.name %>"><%= opt.name %></label>
                 </div>
               </li>

--- a/app/assets/javascripts/views/data_portal/ChartWidgetView.js
+++ b/app/assets/javascripts/views/data_portal/ChartWidgetView.js
@@ -1,15 +1,6 @@
 (function (App) {
   'use strict';
 
-  // This object is used to detect the category of the indicators without having to repeat
-  // the exact name
-  // NOTE: this object is duplicated in ChartWidgetView and ApplyFiltersView; make sure to
-  // update both of them
-  var CATEGORIES = {
-    COMMON: 'Common Indicators',
-    STRAND: 'Financial Access'
-  };
-
   App.View.ChartWidgetView = Backbone.View.extend({
 
     template: JST['templates/data_portal/chart-widget'],
@@ -108,7 +99,7 @@
      */
     _onAnalyze: function () {
       var nonStrandIndicators = this.options.indicators.filter(function (indicator) {
-        return indicator.category !== CATEGORIES.STRAND;
+        return indicator.category !== App.Helper.Indicators.CATEGORIES.STRAND;
       });
 
       new App.Component.ModalChartAnalysis({
@@ -190,7 +181,7 @@
           this.el.innerHTML = this.template({
             name: this.model.get('title'),
             noData: !data.length,
-            canAnalyze: this.options.indicator.category === CATEGORIES.STRAND,
+            canAnalyze: this.options.indicator.category === App.Helper.Indicators.CATEGORIES.STRAND,
             isAnalyzing: !!this.options.analysisIndicator
           });
           this.chartContainer = this.el.querySelector('.js-chart');
@@ -209,7 +200,7 @@
     _getAvailableCharts: function () {
       return this.widgetToolbox.getAvailableCharts().filter(function (chartName) {
         var chart = _.findWhere(App.Helper.ChartConfig, { name: chartName });
-        var isStrandIndicator = this.options.indicator.category === CATEGORIES.STRAND;
+        var isStrandIndicator = this.options.indicator.category === App.Helper.Indicators.CATEGORIES.STRAND;
         var isStrandOnlyChart = !!chart.strandOnly;
         return isStrandIndicator === isStrandOnlyChart;
       }, this);

--- a/app/assets/javascripts/views/data_portal/ChartWidgetView.js
+++ b/app/assets/javascripts/views/data_portal/ChartWidgetView.js
@@ -1,9 +1,10 @@
 (function (App) {
   'use strict';
 
-  // This object is used to detect the category of the indicator without having to repeat
+  // This object is used to detect the category of the indicators without having to repeat
   // the exact name
-  // NOTE: this object is duplicated in DataPortalCountryPage; make sure to update both of them
+  // NOTE: this object is duplicated in ChartWidgetView and ApplyFiltersView; make sure to
+  // update both of them
   var CATEGORIES = {
     COMMON: 'Common Indicators',
     STRAND: 'Financial Access'

--- a/app/assets/javascripts/views/data_portal/FiltersIndicatorsModal.js
+++ b/app/assets/javascripts/views/data_portal/FiltersIndicatorsModal.js
@@ -107,7 +107,16 @@
     _saveCurrentTabData: function () {
       var tab = this.options._tabs[this.options._currentTab];
       var attribute = tab.id === 'select-indicators' ? '_selectedIndicators' : '_selectedFilters';
-      this.options[attribute] = this.filterView.getData();
+      var data = this.filterView.getData();
+
+      if (tab.id === 'select-indicators' && this.options._selectedFilters) {
+        // We need to make sure we don't filter with an invisible indicator
+        this.options._selectedFilters = this.options._selectedFilters.filter(function (selectedFilter) {
+          return _.findWhere(data, { id: selectedFilter });
+        }, this);
+      }
+
+      this.options[attribute] = data;
     },
 
     _onClickDone: function () {

--- a/app/assets/javascripts/views/data_portal/FiltersIndicatorsModal.js
+++ b/app/assets/javascripts/views/data_portal/FiltersIndicatorsModal.js
@@ -12,6 +12,10 @@
       // Callback executed when the user presses the "Done" button
       // The callback gets passed the name of the selected chart
       continueCallback: function () {},
+      // ISO of the country
+      iso: null,
+      // Current year
+      year: null,
       // List of all the possible indicators
       indicators: [],
       // List of filters currently applied
@@ -89,11 +93,12 @@
 
       var View = this.options._tabs[tabIndex].view;
       this.filterView = new View({
+        el: this.$el.find('.js-filters-container'),
+        iso: this.options.iso,
+        year: this.options.year,
         indicators: indicators,
         filters: filters
       });
-
-      this.$el.find('.js-filters-container').html(this.filterView.render().$el);
     },
 
     /**

--- a/app/assets/javascripts/views/data_portal/FiltersIndicatorsModal.js
+++ b/app/assets/javascripts/views/data_portal/FiltersIndicatorsModal.js
@@ -45,11 +45,11 @@
           name: 'Select indicators',
           view: App.View.SelectIndicatorsView
         },
-        // {
-        //   id: 'apply-filters',
-        //   name: 'Apply filters',
-        //   view: App.View.ApplyFiltersView
-        // }
+        {
+          id: 'apply-filters',
+          name: 'Apply filters',
+          view: App.View.ApplyFiltersView
+        }
       ];
 
       this.render();
@@ -83,10 +83,14 @@
         });
       }, this);
 
+      var filters = this.options._selectedFilters
+        ? this.options._selectedFilters
+        : this.options.filters;
+
       var View = this.options._tabs[tabIndex].view;
       this.filterView = new View({
         indicators: indicators,
-        filters: this.options.filters
+        filters: filters
       });
 
       this.$el.find('.js-filters-container').html(this.filterView.render().$el);
@@ -101,54 +105,11 @@
       this.options[attribute] = this.filterView.getData();
     },
 
-    _serializeForm: function(form) {
-      var filters = [],
-        elements = form.querySelectorAll('input, select, textarea'),
-        element,
-        name,
-        value;
-
-      if (elements.length === 0) return null;
-
-      for(var i = 0; i < elements.length; i += 1) {
-        element = elements[i];
-        name = element.name;
-        value = element.value;
-
-        if (element.type === 'checkbox') {
-          if (element.checked) {
-            var entry = _.findWhere(filters, { id: name });
-
-            if (entry === undefined) {
-              entry = {
-                id: name,
-                options: [value]
-              };
-              filters.push(entry);
-            } else {
-              entry.options.push(value);
-            }
-          }
-        }
-      }
-
-      return filters;
-    },
-
     _onClickDone: function () {
-      // var form = document.querySelector('form');
-
-      // if (form === null) {
-      //   this.constructor.__super__.onCloseModal.apply(this);
-      //   return;
-      // }
-
-      // var newFilters = this._serializeForm(form);
-
       // We save the data of the current tab
       this._saveCurrentTabData();
 
-      this.options.continueCallback(this.options._selectedIndicators, []);
+      this.options.continueCallback(this.options._selectedIndicators, this.options._selectedFilters);
       this.onCloseModal();
     },
 

--- a/app/assets/javascripts/views/data_portal/filters/ApplyFiltersView.js
+++ b/app/assets/javascripts/views/data_portal/filters/ApplyFiltersView.js
@@ -14,10 +14,18 @@
     template: JST['templates/data_portal/filters/apply-filters'],
 
     defaults: {
+      // ISO of the country
+      iso: null,
+      // Selected year
+      year: null,
       // List of indicators
       indicators: [],
       // List of the filters
       filters: []
+    },
+
+    events: {
+      'click .js-retry': '_fetchData',
     },
 
     initialize: function (options) {
@@ -25,12 +33,12 @@
       // Filter out the non visible and the strand indicators and copy the entire object to
       // avoid mutations of the original one
       this.options.indicators = this.options.indicators
-        .filter(function (indicator) { return indicator.visible && indicator.category !== CATEGORIES.STRAND && indicator.options && indicator.options.length; })
+        .filter(function (indicator) { return indicator.visible && indicator.category !== CATEGORIES.STRAND; })
         .map(function (indicator) {
           return {
             name: indicator.name,
             id: indicator.id,
-            options: Array.prototype.slice.call(indicator.options, 0)
+            options: indicator.options && Array.prototype.slice.call(indicator.options)
           };
         })
         .sort(function (a, b) {
@@ -38,6 +46,78 @@
           if (a.name > b.name) return 1;
           return 0;
         });
+
+      this._fetchData();
+    },
+
+    /**
+     * Fetch the data necessary for the view and render it
+     */
+    _fetchData: function () {
+      this._showLoader();
+
+      var deferred = $.Deferred();
+
+      var missingIndicators = this.options.indicators.filter(function (indicator) {
+        return !indicator.options || !indicator.options.length;
+      });
+
+      if (missingIndicators.length) {
+        var missingIndicatorsModels = missingIndicators.map(function (missingIndicator) {
+          return new App.Model.IndicatorModel({},
+            {
+              id: missingIndicator.id,
+              iso: this.options.iso,
+              year: this.options.year
+            }
+          );
+        }, this);
+
+        $.when.apply($,
+          missingIndicatorsModels.map(function (missingIndicatorModel) {
+            return missingIndicatorModel.fetch();
+          })
+        ).done(function () {
+          // We copy the options in this.options.indicators
+          missingIndicatorsModels.forEach(function (missingIndicatorModel) {
+            var indicator = _.findWhere(this.options.indicators, { id: missingIndicatorModel.options.id });
+            indicator.options = missingIndicatorModel.get('data').map(function (row) {
+              return row.label;
+            });
+          }, this);
+
+          deferred.resolve();
+        }.bind(this))
+        .fail(deferred.reject);
+      } else {
+        deferred.resolve();
+      }
+
+      deferred
+        .done(function() {
+          this._hideLoader();
+          this.render();
+        }.bind(this))
+        .fail(function () {
+          this.renderError();
+          this._hideLoader();
+        }.bind(this));
+    },
+
+    /**
+     * Show the spinning loader
+     * NOTE: also empties the container
+     */
+    _showLoader: function () {
+      this.el.innerHTML = '';
+      this.el.classList.add('c-spinning-loader');
+    },
+
+    /**
+     * Hide the spinning loader
+     */
+    _hideLoader: function () {
+      this.el.classList.remove('c-spinning-loader');
     },
 
     _getFilteredIndicators: function () {
@@ -84,6 +164,15 @@
       }));
 
       return this;
+    },
+
+    renderError: function () {
+      this.el.innerHTML = '<p class="loading-error">' +
+        'Unable to load the filters' +
+        '<button type="button" class="c-button -retry js-retry">Retry</button>' +
+        '</p>';
+
+      this.setElement(this.el);
     }
 
   });

--- a/app/assets/javascripts/views/data_portal/filters/ApplyFiltersView.js
+++ b/app/assets/javascripts/views/data_portal/filters/ApplyFiltersView.js
@@ -1,54 +1,49 @@
 (function (App) {
 
+   // This object is used to detect the category of the indicators without having to repeat
+  // the exact name
+  // NOTE: this object is duplicated in ChartWidgetView and ApplyFiltersView; make sure to
+  // update both of them
+  var CATEGORIES = {
+    COMMON: 'Common Indicators',
+    STRAND: 'Financial Access'
+  };
+
   App.View.ApplyFiltersView = Backbone.View.extend({
 
     template: JST['templates/data_portal/filters/apply-filters'],
 
     defaults: {
       // List of indicators
-      indicators: []
+      indicators: [],
+      // List of the filters
+      filters: []
     },
 
     initialize: function (options) {
       this.options = _.extend({}, this.defaults, options);
-      // Filter out the non visible widgets and and copy the entire object to
+      // Filter out the non visible and the strand indicators and copy the entire object to
       // avoid mutations of the original one
       this.options.indicators = this.options.indicators
-        .filter(function (indicator) { return indicator.visible && indicator.options && indicator.options.length; })
+        .filter(function (indicator) { return indicator.visible && indicator.category !== CATEGORIES.STRAND && indicator.options && indicator.options.length; })
         .map(function (indicator) {
           return {
             name: indicator.name,
             id: indicator.id,
             options: Array.prototype.slice.call(indicator.options, 0)
           };
+        })
+        .sort(function (a, b) {
+          if (a.name < b.name) return -1;
+          if (a.name > b.name) return 1;
+          return 0;
         });
-
-      // sorts indicator array by indicator name
-      this.options.indicators.sort(function (a, b) {
-        if (a.name > b.name) {
-          return 1;
-        } else if (a.name < b.name) {
-          return -1;
-        }
-
-        return 0;
-      });
-
-      this.filters = options.filters;
     },
 
     _getFilteredIndicators: function () {
       this.options.indicators.forEach(function (indicator) {
-        var isFiltered = _.findWhere(this.filters, { id: indicator.id });
-
-        // We filter to remove the options that don't have a label
-        // Here we assume that all the options that don't are options of a strand
-        // indicator
-        // Strand indicators have each answer duplicated, but with different values:
-        // one for the people who selected the answer, the other for the people who didn't
-        indicator.options = indicator.options.filter(function (option) {
-          return option.length;
-        }).map(function (option, index) {
+        var isFiltered = _.findWhere(this.options.filters, { id: indicator.id });
+        indicator.options = indicator.options.map(function (option, index) {
           return {
             name: option,
             filtered: isFiltered && isFiltered.options.indexOf(option) !== -1
@@ -59,9 +54,28 @@
       return this.options.indicators;
     },
 
-    // TODO
     getData: function () {
-      return [];
+      var options = document.querySelectorAll('.js-option');
+      options = Array.prototype.slice.call(options);
+
+      var filtersGroup = _.groupBy(options, function (option) {
+        return option.dataset.indicator;
+      });
+
+      return Object.keys(filtersGroup)
+        .map(function(indicatorId) {
+          var indicator = _.findWhere(this.options.indicators, { id: indicatorId });
+          return {
+            id: indicatorId,
+            name: indicator.name,
+            options: filtersGroup[indicatorId]
+              .filter(function (option) { return option.checked; })
+              .map(function (option) { return option.value; })
+          };
+        }, this)
+        .filter(function (filter) {
+          return filter.options.length;
+        });
     },
 
     render: function () {

--- a/app/assets/javascripts/views/data_portal/filters/ApplyFiltersView.js
+++ b/app/assets/javascripts/views/data_portal/filters/ApplyFiltersView.js
@@ -1,14 +1,5 @@
 (function (App) {
 
-   // This object is used to detect the category of the indicators without having to repeat
-  // the exact name
-  // NOTE: this object is duplicated in ChartWidgetView and ApplyFiltersView; make sure to
-  // update both of them
-  var CATEGORIES = {
-    COMMON: 'Common Indicators',
-    STRAND: 'Financial Access'
-  };
-
   App.View.ApplyFiltersView = Backbone.View.extend({
 
     template: JST['templates/data_portal/filters/apply-filters'],
@@ -33,7 +24,9 @@
       // Filter out the non visible and the strand indicators and copy the entire object to
       // avoid mutations of the original one
       this.options.indicators = this.options.indicators
-        .filter(function (indicator) { return indicator.visible && indicator.category !== CATEGORIES.STRAND; })
+        .filter(function (indicator) {
+          return indicator.visible && indicator.category !== App.Helper.Indicators.CATEGORIES.STRAND;
+        })
         .map(function (indicator) {
           return {
             name: indicator.name,

--- a/app/assets/javascripts/views/data_portal/filters/SelectIndicatorsView.js
+++ b/app/assets/javascripts/views/data_portal/filters/SelectIndicatorsView.js
@@ -12,6 +12,7 @@
 
     initialize: function (options) {
       this.options = _.extend({}, this.defaults, options);
+      this.render();
     },
 
     /**

--- a/app/assets/stylesheets/components/data-portal/c-modal-filters.scss
+++ b/app/assets/stylesheets/components/data-portal/c-modal-filters.scss
@@ -37,10 +37,29 @@
     }
   }
 
-  .filter-selection {
+  > .filters-container {
     height: 450px;
-    padding: 25px 30px;
     overflow-y: auto;
+    -webkit-overflow-scrolling: touch;
+
+    .loading-error {
+      position: absolute;
+      top: 50%;
+      left: 50%;
+      transform: translate(-50%, -50%);
+      color: $color-1;
+      font-family: $font-family-2;
+      text-align: center;
+
+      .c-button {
+        display: block;
+        margin: 30px auto 0;
+      }
+    }
+  }
+
+  .filter-selection {
+    padding: 25px 30px;
 
     .filter-list > .filter-item {
       width: 100%;
@@ -73,9 +92,7 @@
   }
 
   .select-indicators {
-    height: 450px;
     padding: 25px 30px;
-    overflow-y: auto;
 
     h3 {
       margin: 0 0 10px;

--- a/app/assets/stylesheets/components/data-portal/c-modal-filters.scss
+++ b/app/assets/stylesheets/components/data-portal/c-modal-filters.scss
@@ -62,10 +62,12 @@
     .filter-list > .filter-item > .indicator-filters-list {
       display: flex;
       flex-wrap: wrap;
-      align-items: center;
+      align-items: stretch;
 
       > .indicator-filters-item {
         flex-basis: calc(100% / 3);
+
+        > .c-checkbox { height: 100%; }
       }
     }
   }


### PR DESCRIPTION
This PR restore the filter feature but also brings several changes to it:
1. The strand indicators are not available as filters anymore.
2. In order to render, the `ApplyFiltersView` now always fetch the data of all the visible non-strand indicators. The reason is that the data coming from the widgets can't be accurate (it depends on the current applied filters).
3. The filters based on invisible indicators are never applied.
4. The user can switch between the two tabs of the customise modal without losing the data of each of them.

Because of change `2.`, the number of requests is quite consequent. We'll need to look into caching the data locally.

@andresgnlez Again, quick review. The PR is quite big.