### PR TITLE
Implement the charts' tooltip

### DIFF
--- a/app/assets/javascripts/templates/data_portal/chart-tooltip.jst.ejs
+++ b/app/assets/javascripts/templates/data_portal/chart-tooltip.jst.ejs
@@ -1,0 +1,5 @@
+<h1><%= title %></h1>
+<% if (subtitle) { %>
+  <h2><%= subtitle %></h2>
+<% } %>
+<div class="value"><%= value %></div>

--- a/app/assets/javascripts/templates/data_portal/widgets/analysis.jst.ejs
+++ b/app/assets/javascripts/templates/data_portal/widgets/analysis.jst.ejs
@@ -123,6 +123,8 @@
           "groupby": ["group"],
           "field": "percentage"
         },
+        {"type": "formula", "field": "tooltipTitle", "expr": "datum.label"},
+        {"type": "formula", "field": "tooltipValue", "expr": "format('.2f', datum.percentage) + '%'"},
         {
           "type": "facet",
           "groupby": "group"
@@ -174,6 +176,7 @@
       ],
       "marks": [
         {
+          "name": "hasTooltip",
           "type": "rect",
           "properties": {
             "enter": {

--- a/app/assets/javascripts/templates/data_portal/widgets/bar.jst.ejs
+++ b/app/assets/javascripts/templates/data_portal/widgets/bar.jst.ejs
@@ -21,6 +21,8 @@
         {"type": "cross", "with": "count"},
         {"type": "sort", "by": "-a.percentage"},
         {"type": "rank", "field": "-column"},
+        {"type": "formula", "field": "tooltipTitle", "expr": "datum.a.label"},
+        {"type": "formula", "field": "tooltipValue", "expr": "format('.2f', datum.a.percentage) + '%'"},
         {
           "type": "formula",
           "field": "tickLimit",
@@ -136,6 +138,7 @@
       }
     },
     {
+      "name": "hasTooltip",
       "type": "rect",
       "from": {"data": "table"},
       "properties": {

--- a/app/assets/javascripts/templates/data_portal/widgets/pie.jst.ejs
+++ b/app/assets/javascripts/templates/data_portal/widgets/pie.jst.ejs
@@ -10,6 +10,8 @@
         {"type": "sort","by": "-percentage"},
         {"type": "pie", "field": "percentage"},
         {"type": "rank", "field": "-column"},
+        {"type": "formula", "field": "tooltipTitle", "expr": "datum.label"},
+        {"type": "formula", "field": "tooltipValue", "expr": "format('.2f', datum.percentage) + '%'"},
         {"type": "formula", "field": "label", "expr": "slice(datum.label, 0, 22) + (datum.label.length > 21 ? '...' : '')"}
       ]
     },
@@ -98,6 +100,7 @@
       ]
     },
     {
+      "name": "hasTooltip",
       "type": "arc",
       "from": {
         "data": "table"

--- a/app/assets/javascripts/templates/data_portal/widgets/radial.jst.ejs
+++ b/app/assets/javascripts/templates/data_portal/widgets/radial.jst.ejs
@@ -8,6 +8,7 @@
       "values": <%= data %>,
       "transform": [
         {"type": "filter","test": "datum.label.length"},
+        {"type": "formula", "field": "tooltipTitle", "expr": "datum.label"},
         {"type": "formula", "field": "label", "expr": "slice(datum.label, 0, 22) + (datum.label.length > 21 ? '...' : '')"}
       ]
     },
@@ -26,6 +27,8 @@
       "source": "table",
       "transform": [
         {"type": "cross","with": "count"},
+        {"type": "formula", "field": "tooltipTitle", "expr": "datum.a.tooltipTitle"},
+        {"type": "formula", "field": "tooltipValue", "expr": "format('.2f', datum.a.percentage) + '%'"},
         {
           "type": "formula",
           "field": "label",
@@ -103,6 +106,7 @@
       }
     },
     {
+      "name": "hasTooltip",
       "type": "arc",
       "from": {"data": "final"},
       "properties": {

--- a/app/assets/javascripts/views/data_portal/ChartTooltipView.js
+++ b/app/assets/javascripts/views/data_portal/ChartTooltipView.js
@@ -1,0 +1,90 @@
+(function (App) {
+  'use strict';
+
+  App.View.ChartTooltipView = Backbone.View.extend({
+
+    className: 'c-chart-tooltip',
+
+    template: JST['templates/data_portal/chart-tooltip'],
+
+    defaults: {
+      // Title of the tooltip
+      title: null,
+      // Subtitle of the tooltip
+      subtitle: null,
+      // Value of the tooltip
+      value: null,
+      // DOM element to use as a reference for the positioning of the tooltip
+      reference: null,
+      // Visibility of the tooltip
+      // This is a private attribute, do not change its value outside
+      _visible: false
+    },
+
+    initialize: function (settings) {
+      this.options = _.extend({}, this.defaults, settings);
+      this.render();
+
+      this._onMousemove = this._onMousemove.bind(this);
+
+      this._setListeners();
+    },
+
+    /**
+     * Set the listeners that aren't attached to a DOM node managed by this view
+     */
+    _setListeners: function () {
+      this.options.reference.addEventListener('mousemove', this._onMousemove);
+    },
+
+    /**
+     * Stop the listeners that aren't attached to a DOM node managed by this view
+     */
+    _stopListeners: function () {
+      this.options.reference.removeEventListener('mousemove', this._onMousemove);
+    },
+
+    /**
+     * Event handler executed when the mouse moves
+     * @param {Event} e event
+     */
+    _onMousemove: function (e) {
+      var rects = this.options.reference.getBoundingClientRect();
+      var refX = rects.left;
+      var refY = rects.top;
+
+      var x = e.clientX - refX;
+      var y = e.clientY - refY;
+
+      requestAnimationFrame(function () {
+        if (!this.options.visible) {
+          this.el.style.display = 'block';
+          this.options.visible = true;
+        }
+
+        this.el.style.transform = 'translate(calc(' + x + 'px - 50%), calc(' + y + 'px - 100%))';
+      }.bind(this));
+    },
+
+    /**
+     * Detroy the view and this.el
+     * Inherited from Backbone.View
+     */
+    remove: function () {
+      this._stopListeners();
+      Backbone.View.prototype.remove.call(this);
+    },
+
+    render: function () {
+      this.el.innerHTML = this.template({
+        title: this.options.title,
+        subtitle: this.options.subtitle,
+        value: this.options.value
+      });
+
+      this.options.reference.appendChild(this.el);
+    }
+
+  });
+
+}).call(this, this.App);

--- a/app/assets/javascripts/views/data_portal/ChartWidgetView.js
+++ b/app/assets/javascripts/views/data_portal/ChartWidgetView.js
@@ -148,6 +148,33 @@
     },
 
     /**
+     * Event handler for when an element with tooltip is hovered
+     * in a chart
+     * @param {object} e vega event
+     * @param {object} item vega item
+     */
+    _onMouseoverChart: function (e, item) {
+      if (!item || !item.mark || item.mark.name !== 'hasTooltip') return;
+
+      this.tooltip = new App.View.ChartTooltipView({
+        title: item.datum.tooltipTitle,
+        subtitle: item.datum.tooltipSubtitle || null,
+        value: item.datum.tooltipValue,
+        reference: this.el
+      });
+    },
+
+    /**
+     * Event handler for when an element with tooltip looses its hover
+     * state in a chart
+     */
+    _onMouseoutChart: function () {
+      if (!this.tooltip) return;
+      this.tooltip.remove();
+      this.tooltip = null;
+    },
+
+    /**
      * Fetch the data for the widget
      */
     _fetchData: function () {
@@ -318,6 +345,8 @@
       vg.parse
         .spec(JSON.parse(this._generateVegaSpec()), function (error, chart) {
           this.chart = chart({ el: this.chartContainer, renderer: 'svg' }).update();
+          this.chart.on('mouseover', this._onMouseoverChart.bind(this));
+          this.chart.on('mouseout', this._onMouseoutChart.bind(this));
         }.bind(this));
     },
 

--- a/app/assets/stylesheets/components/data-portal/c-chart-tooltip.scss
+++ b/app/assets/stylesheets/components/data-portal/c-chart-tooltip.scss
@@ -1,0 +1,38 @@
+.c-chart-tooltip {
+  display: none;
+  position: absolute;
+  top: -16px; // Offset between the tip and the cursor
+  left: 0;
+  width: 200px;
+  padding: 10px;
+  border-radius: 2px;
+  background-color: $color-7;
+  font-size: $font-size-s;
+  text-align: center;
+  box-shadow: 0 2px 3px 0 rgba($color-6, .15);
+
+  &::after {
+    display: block;
+    position: absolute;
+    bottom: -6px;
+    left: 50%;
+    transform: translateX(-50%) rotate(-45deg);
+    border-bottom: 12px solid $color-7;
+    border-left: 12px solid $color-7;
+    box-shadow: -2px 2px 3px 0 rgba($color-6, .15);
+    content: '';
+  }
+
+  > h1,
+  > h2 {
+    margin-bottom: 10px;
+    line-height: 1.5;
+    text-transform: uppercase;
+  }
+
+  > .value {
+    font-family: $font-family-2;
+    font-size: $font-size-xs;
+    font-weight: $font-weight-medium;
+  }
+}


### PR DESCRIPTION
This PR adds tooltips to the charts.

<img width="571" alt="Screenshot of a tooltip on top of a slice of a pie chart" src="https://cloud.githubusercontent.com/assets/6073968/24154643/b5813e36-0e49-11e7-95f4-8ffdc4589d58.png">
