### PR TITLE
Let the user change the year of a portal

### DIFF
--- a/app/assets/javascripts/pages/data_portal/DataPortalCountryPage.js
+++ b/app/assets/javascripts/pages/data_portal/DataPortalCountryPage.js
@@ -95,10 +95,13 @@
      * Event listener executed when the filter are updated
      * @param {string[]} visibleIndicators ids of the visible indicators
      * @param { { name: string, options: string[] }[] } filters
+     * @param {number} year
      */
-    _onFiltersUpdate: function (visibleIndicators, filters) {
+    _onFiltersUpdate: function (visibleIndicators, filters, year) {
       if (visibleIndicators) this._updateVisibleIndicators(visibleIndicators);
       if (filters) this._updateFilters(filters);
+      if (year) this._updatedYear(year);
+      this._renderHeader();
       this._renderWidgets();
     },
 
@@ -108,6 +111,29 @@
      */
     _updateFilters: function (filters) {
       this.options._filters = filters;
+    },
+
+    /**
+     * Replace this.options.year and updates the URL
+     * @param {number} year
+     */
+    _updatedYear: function (year) {
+      if (this.options.year === year) return;
+
+      this.options.year = year;
+      this._updateURL();
+    },
+
+    /**
+     * Update the URL according to the state of the application
+     */
+    _updateURL: function () {
+      var url = '/data-portal/' + this.options.iso + '/' + this.options.year;
+
+      // Adding { turbolinks: {} } is mandatory to avoid breaking the browser's back button
+      // because Turbolinks doesn't handle well the URL changes
+      // Check here: https://github.com/turbolinks/turbolinks/issues/219
+      history.replaceState({ turbolinks: {} }, '', url);
     },
 
     /**

--- a/app/assets/javascripts/templates/data_portal/filters/select-context.jst.ejs
+++ b/app/assets/javascripts/templates/data_portal/filters/select-context.jst.ejs
@@ -1,0 +1,13 @@
+<div class="select-context">
+  <h3>Select year</h3>
+  <ul>
+    <% years.forEach(function (year) { %>
+      <li>
+        <div class="c-radio-button">
+          <input type="radio" id="year-<%= year.value %>" name="year" value="<%= year.value %>" class="js-year" <%= year.active ? 'checked' : '' %> />
+          <label for="year-<%= year.value %>"><%= year.value %></label>
+        </div>
+      </li>
+    <% }) %>
+  </ul>
+</div>

--- a/app/assets/javascripts/views/data_portal/FiltersIndicatorsModal.js
+++ b/app/assets/javascripts/views/data_portal/FiltersIndicatorsModal.js
@@ -4,7 +4,7 @@
 
     defaults: {
       // See App.Component.Modal for details about this option
-      title: 'Select indicators',
+      title: 'Customize indicators',
       // See App.Component.Modal for details about this option
       showTitle: true,
       // See App.Component.Modal for details about this option
@@ -28,7 +28,9 @@
       // List of the selected indicators in the modal
       _selectedIndicators: null,
       // List of selected filters in the modal
-      _selectedFilters: null
+      _selectedFilters: null,
+      // Selected year in the modal
+      _selectedYear: null
     },
 
     events: function () {
@@ -53,6 +55,11 @@
           id: 'apply-filters',
           name: 'Apply filters',
           view: App.View.ApplyFiltersView
+        },
+        {
+          id: 'select-context',
+          name: 'Select context',
+          view: App.View.SelectContextView
         }
       ];
 
@@ -91,11 +98,15 @@
         ? this.options._selectedFilters
         : this.options.filters;
 
+      var year = this.options._selectedYear
+        ? this.options._selectedYear
+        : this.options.year;
+
       var View = this.options._tabs[tabIndex].view;
       this.filterView = new View({
         el: this.$el.find('.js-filters-container'),
         iso: this.options.iso,
-        year: this.options.year,
+        year: year,
         indicators: indicators,
         filters: filters
       });
@@ -106,9 +117,22 @@
      */
     _saveCurrentTabData: function () {
       var tab = this.options._tabs[this.options._currentTab];
-      var attribute = tab.id === 'select-indicators' ? '_selectedIndicators' : '_selectedFilters';
-      var data = this.filterView.getData();
 
+      var attribute;
+      switch (tab.id) {
+        case 'apply-filters':
+          attribute = '_selectedFilters';
+          break;
+
+        case 'select-context':
+          attribute = '_selectedYear';
+          break;
+
+        default:
+          attribute = '_selectedIndicators';
+      }
+
+      var data = this.filterView.getData();
       this.options[attribute] = data;
     },
 
@@ -116,7 +140,7 @@
       // We save the data of the current tab
       this._saveCurrentTabData();
 
-      this.options.continueCallback(this.options._selectedIndicators, this.options._selectedFilters);
+      this.options.continueCallback(this.options._selectedIndicators, this.options._selectedFilters, this.options._selectedYear);
       this.onCloseModal();
     },
 

--- a/app/assets/javascripts/views/data_portal/filters/ApplyFiltersView.js
+++ b/app/assets/javascripts/views/data_portal/filters/ApplyFiltersView.js
@@ -16,7 +16,7 @@
     },
 
     events: {
-      'click .js-retry': '_fetchData',
+      'click .js-retry-filters': '_fetchData',
     },
 
     initialize: function (options) {
@@ -147,7 +147,7 @@
     renderError: function () {
       this.el.innerHTML = '<p class="loading-error">' +
         'Unable to load the filters' +
-        '<button type="button" class="c-button -retry js-retry">Retry</button>' +
+        '<button type="button" class="c-button -retry js-retry-filters">Retry</button>' +
         '</p>';
 
       this.setElement(this.el);

--- a/app/assets/javascripts/views/data_portal/filters/SelectContextView.js
+++ b/app/assets/javascripts/views/data_portal/filters/SelectContextView.js
@@ -1,0 +1,94 @@
+(function (App) {
+
+  var Collection = Backbone.Collection.extend({
+
+    initialize: function (attributes, options) {
+      this.options = _.extend({}, options);
+    },
+
+    url: function () {
+      return API_URL + '/country/';
+    },
+
+    parse: function (data) {
+      return _.findWhere(data, { iso: this.options.iso })
+        .year
+        .map(function (years) {
+          return { value: years.year };
+        });
+    }
+
+  });
+
+  App.View.SelectContextView = Backbone.View.extend({
+
+    template: JST['templates/data_portal/filters/select-context'],
+
+    defaults: {
+      // Current ISO
+      iso: null,
+      // Current year
+      year: null
+    },
+
+    events: {
+      'click .js-retry-context': '_fetchData',
+    },
+
+    initialize: function (options) {
+      this.options = _.extend({}, this.defaults, options);
+      this.collection = new Collection({}, { iso: this.options.iso });
+      this._fetchData();
+    },
+
+    /**
+     * Fetch the list of years and render the View
+     */
+    _fetchData: function () {
+      this.collection.fetch()
+        .done(this.render.bind(this))
+        .fail(this.renderError.bind(this));
+    },
+
+    /**
+     * Return the data associated with the tab
+     * @returns {number}
+     */
+    getData: function () {
+      var selectedRadio = document.querySelector('.js-year:checked');
+      return +selectedRadio.value;
+    },
+
+    /**
+     * Return the list of years to be rendered
+     * @returns {{ value: number, active: boolean }[]}
+     */
+    _getYears: function () {
+      return this.collection.toJSON()
+        .map(function (year) {
+          return {
+            value: year.value,
+            active: year.value === this.options.year
+          };
+        }, this);
+    },
+
+    render: function () {
+      this.el.innerHTML = this.template({
+        years: this._getYears()
+      });
+
+      return this;
+    },
+
+    renderError: function () {
+      this.el.innerHTML = '<p class="loading-error">' +
+        'Unable to load the context options' +
+        '<button type="button" class="c-button -retry js-retry-context">Retry</button>' +
+        '</p>';
+
+      this.setElement(this.el);
+    }
+
+  });
+}.call(this, this.App));

--- a/app/assets/stylesheets/components/data-portal/c-modal-filters.scss
+++ b/app/assets/stylesheets/components/data-portal/c-modal-filters.scss
@@ -91,7 +91,8 @@
     }
   }
 
-  .select-indicators {
+  .select-indicators,
+  .select-context {
     padding: 25px 30px;
 
     h3 {

--- a/app/assets/stylesheets/components/shared/c-radio-button.scss
+++ b/app/assets/stylesheets/components/shared/c-radio-button.scss
@@ -29,7 +29,7 @@ $radio-button-padding: 25px;
     display: inline-block;
     flex-basis: 100%;
     padding: $radio-button-padding $radio-button-padding $radio-button-padding #{ 2 * $radio-button-padding};
-    font-family: $font-family-2;
+    font-family: $font-family-1;
     font-weight: $font-weight-medium;
     cursor: pointer;
 


### PR DESCRIPTION
This PR lets the user change the year of a portal. It is part of the new "context" tab of the "customise" modal.

<img width="926" alt="Screenshot of the year options in the modal" src="https://cloud.githubusercontent.com/assets/6073968/24210269/7d9bfc86-0f20-11e7-8a9a-708f404cce59.png">

[Pivotal task](https://www.pivotaltracker.com/story/show/141321617)