### PR TITLE
Compare an indicator with other countries/years or other jurisdictions

### DIFF
--- a/app/assets/javascripts/components/data_portal/modals/modal-chart-compare.js
+++ b/app/assets/javascripts/components/data_portal/modals/modal-chart-compare.js
@@ -27,6 +27,7 @@
       // The callback doesn't receive any parameter
       stopCompareCallback: function () {},
       // Index of the current tab
+      // NOTE: the value is updated at instantiation
       _currentTab: 0,
       // List of the tabs
       // This attribute is modified at instantiation time
@@ -49,8 +50,19 @@
           id: 'country-year',
           name: 'Country and year',
           view: App.View.CountryYearView
+        },
+        {
+          id: 'jurisdiction',
+          name: 'Jurisdiction in ' + App.Helper.Indicators.COUNTRIES[this.options.iso] + ' in ' + this.options.year,
+          view: App.View.JurisdictionView
         }
       ];
+
+      // If the compare indicators the view gets passed are jurisdiction indicators
+      // then the default tab is the second
+      if (this._isJurisdictionsCompareIndicators()) {
+        this.options._currentTab = 1;
+      }
 
       this.render();
     },
@@ -59,6 +71,10 @@
       this.constructor.__super__._setEventListeners.apply(this);
 
       this.listenTo(this.tabView, 'tab:selected', function (tab) {
+        // We delete the previous data when the tab is changed
+        // to avoid leaks between tabs
+        this.options.compareIndicators = null;
+
         this._onTabSelected(tab.id);
       }.bind(this));
     },
@@ -98,6 +114,21 @@
       });
 
       this.setElement(this.el);
+    },
+
+    /**
+     * Return whether the compare indicators passed to the view correspond
+     * to data of the Jurisdiction tab
+     * @return {boolean}
+     */
+    _isJurisdictionsCompareIndicators: function () {
+      return !!this.options.compareIndicators
+        && this.options.compareIndicators.reduce(function (res, compareIndicator) {
+          return compareIndicator.filters
+            && compareIndicator.filters.length
+            && !!_.findWhere(compareIndicator.filters, { id: 'jurisdiction' })
+            || res;
+        }, false);
     },
 
     /**

--- a/app/assets/javascripts/components/data_portal/modals/modal-chart-compare.js
+++ b/app/assets/javascripts/components/data_portal/modals/modal-chart-compare.js
@@ -1,0 +1,131 @@
+(function (App) {
+
+  App.Component.ModalChartCompare = App.Component.Modal.extend({
+
+    contentTemplate: JST['templates/data_portal/modals/modal-chart-compare'],
+
+    defaults: {
+      // See App.Component.Modal for details about this option
+      title: 'Compare data',
+      // See App.Component.Modal for details about this option
+      showTitle: true,
+      // See App.Component.Modal for details about this option
+      footer: '<button type="button" class="c-button -padding -white -outline js-cancel">Cancel</button><button type="button" class="c-button -padding -no-hover -white js-done">Done</button>',
+      // Indicator being compared
+      indicator: null,
+      // Current ISO of the portal
+      iso: null,
+      // Current year of the portal
+      year: null,
+      // List of the indicators used for the comparison
+      // See "compareIndicators" in App.View.ChartWidgetView for the format
+      compareIndicators: [],
+      // Callback executed when the user presses the "Done" button
+      // The callback gets passed the name of the selected chart
+      continueCallback: function () {},
+      // Callback executed when the user presses the "Clear comparison" button
+      // The callback doesn't receive any parameter
+      stopCompareCallback: function () {},
+      // Index of the current tab
+      _currentTab: 0,
+      // List of the tabs
+      // This attribute is modified at instantiation time
+      _tabs: [],
+    },
+
+    events: function () {
+      return _.extend({}, App.Component.Modal.prototype.events, {
+        'click .js-cancel': 'onCloseModal',
+        'click .js-done': '_onClickDone',
+        'click .js-clear-comparison': '_onClickClearCompare'
+      });
+    },
+
+    initialize: function (options) {
+      this.constructor.__super__.initialize.call(this, options);
+
+      this.options._tabs = [
+        {
+          id: 'country-year',
+          name: 'Country and year',
+          view: App.View.CountryYearView
+        }
+      ];
+
+      this.render();
+    },
+
+    _setEventListeners: function () {
+      this.constructor.__super__._setEventListeners.apply(this);
+
+      this.listenTo(this.tabView, 'tab:selected', function (tab) {
+        this._onTabSelected(tab.id);
+      }.bind(this));
+    },
+
+    /**
+     * Event handler for when the "Done" button is clicked
+     */
+    _onClickDone: function () {
+      var compareIndicators = this._getCompareIndicators();
+      this.options.continueCallback(compareIndicators);
+      this.onCloseModal();
+    },
+
+    /**
+     * Event handler for when the "Clear comparison" button is clicked
+     */
+    _onClickClearCompare: function () {
+      this.options.stopCompareCallback();
+      this.onCloseModal();
+    },
+
+    /**
+     * Event handler executed when the user switch from one tab to another
+     * @param {string} tabId
+     */
+    _onTabSelected: function (tabId) {
+      var tabIndex = _.findIndex(this.options._tabs, { id: tabId });
+      this.options._currentTab = tabIndex;
+
+      var View = this.options._tabs[tabIndex].view;
+      this.compareView = new View({
+        el: this.$el.find('.js-container'),
+        iso: this.options.iso,
+        year: this.options.year,
+        indicator: this.options.indicator,
+        compareIndicators: this.options.compareIndicators
+      });
+
+      this.setElement(this.el);
+    },
+
+    /**
+     * Return the list of indicators for the comparison
+     * @return { { id: string, year: number, iso: string, filters: { id: string, name: string, options: string[] }[] }[] }
+     */
+    _getCompareIndicators: function () {
+      return this.compareView.getData();
+    },
+
+    render: function () {
+      this.options.content = this.contentTemplate({
+        indicator: this.options.indicator.name,
+        country: App.Helper.Indicators.COUNTRIES[this.options.iso],
+        year: this.options.year
+      });
+
+      this.constructor.__super__.render.apply(this);
+
+      this.tabView = new App.View.TabView({
+        el: this.el.querySelector('.js-tabs'),
+        tabs: this.options._tabs,
+        currentTab: this.options._currentTab
+      });
+
+      this._setEventListeners();
+      this._onTabSelected(this.options._tabs[this.options._currentTab].id);
+    }
+
+  });
+}).call(this, this.App);

--- a/app/assets/javascripts/helpers/chartConfig.js
+++ b/app/assets/javascripts/helpers/chartConfig.js
@@ -37,5 +37,21 @@
       // If not set, use the default one in App.View.ChartWidgetView
       ratio: 0.3
     },
+    {
+      name: 'analysis',
+      // The following attribute is not part of the Jiminy requirements
+      // It's used to hide the chart from the chart selector
+      visible: false
+    },
+    {
+      name: 'compare',
+      // The following attribute is not part of the Jiminy requirements
+      // It's used to hide the chart from the chart selector
+      visible: false,
+      // The following attribute is not part of the Jiminy requirements
+      // Ratio between the width and the height
+      // If not set, use the default one in App.View.ChartWidgetView
+      ratio: 0.3
+    }
   ];
 })(this.App));

--- a/app/assets/javascripts/helpers/indicators.js
+++ b/app/assets/javascripts/helpers/indicators.js
@@ -4,6 +4,18 @@
     CATEGORIES: {
       COMMON: 'Common Indicators',
       STRAND: 'Financial Access'
+    },
+
+    // Map for the ISO and country names
+    COUNTRIES: {
+      UGA: 'Uganda',
+      TZA: 'Tanzania',
+      ZMB: 'Zambia',
+      RWA: 'Rwanda',
+      GHA: 'Ghana',
+      KEN: 'Kenya',
+      MOZ: 'Mozambique',
+      PAK: 'Pakistan'
     }
   };
 })(this.App));

--- a/app/assets/javascripts/helpers/widgetToolbox.js
+++ b/app/assets/javascripts/helpers/widgetToolbox.js
@@ -23,7 +23,11 @@
    * @returns {object} instance
    */
   App.Helper.WidgetToolbox.prototype._getJiminyInstance = function () {
-    return new Jiminy(this.dataset, App.Helper.ChartConfig);
+    var chartConfig = App.Helper.ChartConfig.filter(function (chart) {
+      return chart.visible !== false;
+    });
+
+    return new Jiminy(this.dataset, chartConfig);
   };
 
   /**

--- a/app/assets/javascripts/models/data_portal/ChartWidgetModel.js
+++ b/app/assets/javascripts/models/data_portal/ChartWidgetModel.js
@@ -21,15 +21,33 @@
         filters: [],
         // Id of the indicator used for the analysis
         // NOTE: can't be modified after instantiation
-        analysisIndicatorId: null
+        analysisIndicatorId: null,
+        // List of the indicators used for the comparison
+        // Check the property in App.View.ChartWidgetView to see the format
+        compareIndicators: null
       }, options);
 
       this.indicatorModel = new App.Model.IndicatorModel({}, this.options);
+
       if (this.options.analysisIndicatorId) {
         this.analysisIndicatorModel = new App.Model.IndicatorModel(
           {},
           _.extend({}, this.options, { id: this.options.analysisIndicatorId })
         );
+      }
+
+      if (this.options.compareIndicators) {
+        this.compareIndicatorsModels = this.options.compareIndicators.map(function (compareIndicator) {
+          return new App.Model.IndicatorModel(
+            {},
+            {
+              id: compareIndicator.id,
+              iso: compareIndicator.iso,
+              year: compareIndicator.year,
+              filters: compareIndicator.filters || []
+            }
+          )
+        });
       }
     },
 
@@ -85,7 +103,7 @@
     },
 
     /**
-     * Join the partial indicators to form the complete datasets
+     * Join the partial indicators to form the complete dataset
      * Each row will get a "group" attribute with the name of the column used to retrieve the data
      * @returns {object[]}
      */
@@ -93,9 +111,7 @@
       var analysisColumns = this._getAnalysisColumns();
 
       // List of all the partial indicators
-      var partialIndicators = Array.prototype.slice.call(arguments).map(function (arg) {
-        return arg;
-      });
+      var partialIndicators = Array.prototype.slice.call(arguments);
 
       var res = _.extend({}, partialIndicators[0], { data: [] });
 
@@ -114,20 +130,69 @@
     },
 
     /**
+     * Return the name of the compare group
+     * @param {object} model Model of the partial indicator
+     * @returns {string}
+     */
+    _getCompareGroupName: function (model) {
+      if (model.options.filters && model.options.filters.length) {
+        return model.options.filters[0].options[0] + ' ' + model.options.year;
+      } else {
+        return App.Helper.Indicators.COUNTRIES[model.options.iso] + ' ' + model.options.year;
+      }
+    },
+
+    /**
+     * Fetch the partial indicators for the comparison
+     * A partial indicator represent the data of an indicator used for the comparison
+     * @returns {object} $.Deferred
+     */
+    _fetchComparePartials: function () {
+      return $.when.apply($,
+        this.compareIndicatorsModels.map(function (compareIndicatorsModel) {
+          // We can't directly return compareIndicatorsModel.fetch() here because we need the
+          // data to be parsed
+          var deferred = $.Deferred();
+          compareIndicatorsModel.fetch()
+            .done(function () { deferred.resolve(compareIndicatorsModel.toJSON()); })
+            .fail(deferred.reject);
+          return deferred;
+        })
+      );
+    },
+
+    /**
+     * Join the partial indicators to form the complete dataset
+     * Each row will get a "group" attribute with the name of the data represented
+     * @returns {object[]}
+     */
+    _joinComparePartials: function () {
+      var res = this.indicatorModel.toJSON();
+      res.data = res.data.map(function (row) {
+        return _.extend({}, row, { group: this._getCompareGroupName(this.indicatorModel) });
+      }, this);
+
+      // We append the data of each partial indicator, changing the name of the group each time
+      this.compareIndicatorsModels.forEach(function (compareIndicatorModel) {
+        var data = compareIndicatorModel.get('data');
+        data = data.map(function (row) {
+          return _.extend({}, row, { group: this._getCompareGroupName(compareIndicatorModel) });
+        }, this);
+
+        res.data = res.data.concat(data);
+      }, this);
+
+      return res;
+    },
+
+    /**
      * Fetch the model's data
      * @returns {object} $.Deferred
      */
     fetch: function () {
       var deferred = $.Deferred();
 
-      if (!this.analysisIndicatorModel) {
-        this.indicatorModel.fetch()
-          .done(function() {
-            this.set(this.indicatorModel.toJSON());
-            deferred.resolve.apply(this, arguments);
-          }.bind(this))
-          .fail(deferred.reject);
-      } else {
+      if (this.analysisIndicatorModel) {
         // We first need to fetch the data of the indicator used for the
         // analysis in order to get its columns
         this.analysisIndicatorModel.fetch()
@@ -139,6 +204,25 @@
           .then(this._joinAnalysisPartials.bind(this))
           .done(function(data) {
             this.set(data);
+            deferred.resolve.apply(this, arguments);
+          }.bind(this))
+          .fail(deferred.reject);
+      } else if (this.compareIndicatorsModels) {
+        // We first fetch the data of the indicator
+        this.indicatorModel.fetch()
+          // We then fetch the data of all the indicators used for the comparison
+          .then(this._fetchComparePartials.bind(this))
+          // We finally join the data
+          .then(this._joinComparePartials.bind(this))
+          .done(function (data) {
+            this.set(data)
+            deferred.resolve.apply(this, arguments);
+          }.bind(this))
+          .fail(deferred.reject);
+      } else {
+        this.indicatorModel.fetch()
+          .done(function() {
+            this.set(this.indicatorModel.toJSON());
             deferred.resolve.apply(this, arguments);
           }.bind(this))
           .fail(deferred.reject);

--- a/app/assets/javascripts/models/data_portal/ChartWidgetModel.js
+++ b/app/assets/javascripts/models/data_portal/ChartWidgetModel.js
@@ -44,10 +44,10 @@
               id: compareIndicator.id,
               iso: compareIndicator.iso,
               year: compareIndicator.year,
-              filters: compareIndicator.filters || []
+              filters: (this.options.filters || []).concat(compareIndicator.filters)
             }
           )
-        });
+        }, this);
       }
     },
 

--- a/app/assets/javascripts/pages/data_portal/DataPortalCountryPage.js
+++ b/app/assets/javascripts/pages/data_portal/DataPortalCountryPage.js
@@ -37,18 +37,6 @@
     { id: 'insurance_strand', name: 'Insurance', category: 'Financial Access', visible: false }
   ];
 
-  // This will be removed when we have a way to get the country name from the API
-  var COUNTRIES = {
-    UGA: 'Uganda',
-    TZA: 'Tanzania',
-    ZMB: 'Zambia',
-    RWA: 'Rwanda',
-    GHA: 'Ghana',
-    KEN: 'Kenya',
-    MOZ: 'Mozambique',
-    PAK: 'Pakistan'
-  };
-
   App.Page.DataPortalCountryPage = Backbone.View.extend({
 
     el: 'body',
@@ -202,7 +190,7 @@
         error: this._loadingError,
         indicators: this.indicatorsCollection.toJSON(),
         year: this.options.year,
-        country: COUNTRIES[this.options.iso]
+        country: App.Helper.Indicators.COUNTRIES[this.options.iso]
       });
     },
 

--- a/app/assets/javascripts/templates/data_portal/chart-widget.jst.ejs
+++ b/app/assets/javascripts/templates/data_portal/chart-widget.jst.ejs
@@ -4,7 +4,7 @@
   <div class="toolbar">
     <button type="button" class="c-button -mini js-save">Save</button>
     <button type="button" class="c-button -mini js-change">Change</button>
-    <button type="button" class="c-button -mini js-compare">Compare</button>
+    <% if (canCompare) { %><button type="button" class="c-button -mini js-compare" aria-pressed="<%= isComparing %>">Compare</button><% } %>
     <% if (canAnalyze) { %><button type="button" class="c-button -mini js-analyze" aria-pressed="<%= isAnalyzing %>">Analyse</button><% } %>
   </div>
 </div>

--- a/app/assets/javascripts/templates/data_portal/compare/country-year.jst.ejs
+++ b/app/assets/javascripts/templates/data_portal/compare/country-year.jst.ejs
@@ -1,0 +1,20 @@
+<div class="country-year">
+  <button class="c-button -mini js-clear-comparison">Clear comparison</button>
+  <div class="countries-list">
+    <% countries.forEach(function (country) { %>
+      <div>
+        <%= country.name %>
+        <ul class="years-list">
+          <% country.years.forEach(function (year) { %>
+            <li>
+              <div class="c-checkbox">
+                <input type="checkbox" id="<%= country.name %>-<%= year.value %>" value="<%= year.value %>" class="js-year" data-iso="<%= country.iso %>" <%= year.active ? 'checked' : '' %> <%= year.disabled ? 'disabled' : '' %> />
+                <label for="<%= country.name %>-<%= year.value %>"><%= year.value %></label>
+              </div>
+            </li>
+          <% }) %>
+        </ul>
+      </div>
+    <% }) %>
+  </div>
+</div>

--- a/app/assets/javascripts/templates/data_portal/compare/country-year.jst.ejs
+++ b/app/assets/javascripts/templates/data_portal/compare/country-year.jst.ejs
@@ -1,5 +1,4 @@
 <div class="country-year">
-  <button class="c-button -mini js-clear-comparison">Clear comparison</button>
   <div class="countries-list">
     <% countries.forEach(function (country) { %>
       <div>

--- a/app/assets/javascripts/templates/data_portal/compare/jurisdiction.jst.ejs
+++ b/app/assets/javascripts/templates/data_portal/compare/jurisdiction.jst.ejs
@@ -1,0 +1,13 @@
+<div class="jurisdiction">
+  <button class="c-button -mini js-clear-comparison">Clear comparison</button>
+  <ul class="jurisdications-list">
+    <% jurisdictions.forEach(function (jurisdiction) { %>
+      <li>
+        <div class="c-checkbox">
+          <input type="checkbox" id="<%= jurisdiction.name %>" value="<%= jurisdiction.name %>" class="js-jurisdiction" <%= jurisdiction.active ? 'checked' : '' %> <%= jurisdiction.disabled ? 'disabled' : '' %> />
+          <label for="<%= jurisdiction.name %>"><%= jurisdiction.name %></label>
+        </div>
+      </li>
+    <% }) %>
+  </ul>
+</div>

--- a/app/assets/javascripts/templates/data_portal/compare/jurisdiction.jst.ejs
+++ b/app/assets/javascripts/templates/data_portal/compare/jurisdiction.jst.ejs
@@ -1,5 +1,4 @@
 <div class="jurisdiction">
-  <button class="c-button -mini js-clear-comparison">Clear comparison</button>
   <ul class="jurisdications-list">
     <% jurisdictions.forEach(function (jurisdiction) { %>
       <li>

--- a/app/assets/javascripts/templates/data_portal/modals/modal-chart-compare.jst.ejs
+++ b/app/assets/javascripts/templates/data_portal/modals/modal-chart-compare.jst.ejs
@@ -2,6 +2,12 @@
   <div class="header">
     Select up to three elements to compare <span><%= indicator %></span> in <span><%= country %></span> in <span><%= year %></span> with...
   </div>
-  <div class="compare-tabs js-tabs"></div>
-  <div class="compare-container js-container"></div>
+  <button class="c-button -mini js-clear-comparison">Clear comparison</button>
+  <% tabs.forEach(function (tab, index) { %>
+    <div class="c-radio-button">
+      <input type="radio" name="compare" id="compare-<%= tab.id %>" class="js-compare" value="<%= tab.id %>" <%= index === currentTab ? 'checked' : '' %>>
+      <label for="compare-<%= tab.id %>"><%= tab.name %></label>
+    </div>
+    <div class="compare-container js-container js-container-<%= tab.id %>"></div>
+  <% }) %>
 </div>

--- a/app/assets/javascripts/templates/data_portal/modals/modal-chart-compare.jst.ejs
+++ b/app/assets/javascripts/templates/data_portal/modals/modal-chart-compare.jst.ejs
@@ -1,0 +1,7 @@
+<div class="c-modal-chart-compare">
+  <div class="header">
+    Select up to three elements to compare <span><%= indicator %></span> in <span><%= country %></span> in <span><%= year %></span> with...
+  </div>
+  <div class="compare-tabs js-tabs"></div>
+  <div class="compare-container js-container"></div>
+</div>

--- a/app/assets/javascripts/templates/data_portal/widgets/compare.jst.ejs
+++ b/app/assets/javascripts/templates/data_portal/widgets/compare.jst.ejs
@@ -8,6 +8,7 @@
       "values": <%= data %>,
       "transform": [
         {"type": "filter","test": "datum.label.length"},
+        {"type": "formula", "field": "tooltipTitle", "expr": "datum.label"},
         {
           "type": "formula",
           "field": "label",
@@ -155,6 +156,8 @@
           "field": "group",
           "expr": "datum.a.group"
         },
+        {"type": "formula", "field": "tooltipTitle", "expr": "datum.a.tooltipTitle"},
+        {"type": "formula", "field": "tooltipValue", "expr": "format('.2f', datum.a.percentage) + '%'"},
         {
           "type": "facet",
           "groupby": ["group"]
@@ -266,6 +269,7 @@
           }
         },
         {
+          "name": "hasTooltip",
           "type": "arc",
           "properties": {
             "enter": {
@@ -276,75 +280,6 @@
               "startAngle": {"value": 0},
               "endAngle": {"field": "a.percentage","scale": "radius"},
               "fill": {"field": "a.label","scale": "color"}
-            }
-          }
-        }
-      ]
-    },
-    {
-      "type": "group",
-      "from": {
-        "data": "ungrouped",
-        "transform": [
-          {
-            "type": "formula",
-            "field": "size",
-            "expr": "datum.lineCapDiameter * datum.lineCapDiameter - 10"
-          },
-          {
-            "type": "formula",
-            "field": "endCapAngle",
-            "expr": "scale('radius', datum.a.percentage)"
-          },
-          {
-            "type": "formula",
-            "field": "endCapX",
-            "expr": "cos(datum.endCapAngle - 1.5707963268) * datum.lineCapRadiusPos"
-          },
-          {
-            "type": "formula",
-            "field": "endCapY",
-            "expr": "sin(datum.endCapAngle - 1.5707963268) * datum.lineCapRadiusPos"
-          }
-        ]
-      },
-      "properties": {
-        "enter": {
-          "x": {"scale": "x","field": "a.label"},
-          "y": {"field": {"group": "height"},"mult": 0.5}
-        }
-      },
-      "marks": [
-        {
-          "type": "symbol",
-          "properties": {
-            "enter": {
-              "x": {"value": 0},
-              "y": {
-                "field": {"parent": "lineCapRadiusPos"},
-                "mult": -1
-              },
-              "shape": "circle",
-              "size": {"field": {"parent": "size"}},
-              "fill": {
-                "field": {"parent": "a.label"},
-                "scale": "color"
-              }
-            }
-          }
-        },
-        {
-          "type": "symbol",
-          "properties": {
-            "enter": {
-              "x": {"field": {"parent": "endCapX"}},
-              "y": {"field": {"parent": "endCapY"}},
-              "shape": "circle",
-              "size": {"field": {"parent": "size"}},
-              "fill": {
-                "field": {"parent": "a.label"},
-                "scale": "color"
-              }
             }
           }
         }

--- a/app/assets/javascripts/templates/data_portal/widgets/compare.jst.ejs
+++ b/app/assets/javascripts/templates/data_portal/widgets/compare.jst.ejs
@@ -1,0 +1,480 @@
+{
+  "width": <%= width %>,
+  "height": <%= height %>,
+  "padding": "strict",
+  "data": [
+    {
+      "name": "table",
+      "values": <%= data %>,
+      "transform": [
+        {"type": "filter","test": "datum.label.length"},
+        {
+          "type": "formula",
+          "field": "label",
+          "expr": "slice(datum.label, 0, 22) + (datum.label.length > 21 ? '...' : '')"
+        }
+      ]
+    },
+    {
+      "name": "countCircles",
+      "source": "table",
+      "transform": [
+        {
+          "type": "aggregate",
+          "summarize": {"label": "distinct"}
+        },
+        {
+          "type": "formula",
+          "field": "count_label",
+          "expr": "datum.distinct_label"
+        }
+      ]
+    },
+    {
+      "name": "groups",
+      "source": "table",
+      "transform": [
+        {
+          "type": "facet",
+          "groupby": ["group"]
+        },
+        {
+          "type": "rank"
+        },
+        {
+          "type": "formula",
+          "field": "rank",
+          "expr": "datum.rank - 1"
+        }
+      ]
+    },
+    {
+      "name": "countGroups",
+      "source": "groups",
+      "transform": [
+        {
+          "type": "aggregate",
+          "summarize": {"group": "count"}
+        }
+      ]
+    },
+    {
+      "name": "final",
+      "source": "table",
+      "transform": [
+        {"type": "cross","with": "countCircles"},
+        {
+          "type": "formula",
+          "field": "label",
+          "expr": "datum.b.count_label === 5 ? (slice(datum.a.label, 0, 19) + (datum.a.label.length > 18 ? '...' : '')) : (slice(datum.a.label, 0, 26) + (datum.a.label.length > 25 ? '...' : ''))"
+        },
+        {
+          "type": "formula",
+          "field": "outerRadius",
+          <%/* Replace the value 5 by datum.b.count_label here to have a dynamic circle size */%>
+          "expr": "0.5 * (<%= isNaN(width) ? '0' : width %> - (5 - 1) * 50) / 5"
+        },
+        {
+          "type": "formula",
+          "field": "innerRadius",
+          "expr": "datum.outerRadius - 7"
+        },
+        {
+          "type": "formula",
+          "field": "lineCapDiameter",
+          "expr": "(datum.outerRadius - datum.innerRadius)"
+        },
+        {
+          "type": "formula",
+          "field": "lineCapRadiusPos",
+          "expr": "datum.innerRadius + datum.lineCapDiameter / 2"
+        },
+        {
+          "type": "formula",
+          "field": "labelPos",
+          "expr": "(<%= isNaN(height) ? '0' : height %> - datum.outerRadius * 2) / 4"
+        }
+      ]
+    },
+    {
+      "name": "ungrouped",
+      "source": "table",
+      "transform": [
+        {
+          "type": "lookup",
+          "on": "groups",
+          "keys": ["group"],
+          "onKey": "group",
+          "as": "groupDetail"
+        },
+        {
+          "type": "formula",
+          "field": "pos",
+          "expr": "datum.groupDetail.rank"
+        },
+        {"type": "cross","with": "countCircles"},
+        {
+          "type": "formula",
+          "field": "label",
+          "expr": "datum.b.count_label === 5 ? (slice(datum.a.label, 0, 19) + (datum.a.label.length > 18 ? '...' : '')) : (slice(datum.a.label, 0, 26) + (datum.a.label.length > 25 ? '...' : ''))"
+        },
+        {
+          "type": "formula",
+          "field": "outerRadius",
+          <%/* Replace the value 5 by datum.b.count_label here to have a dynamic circle size */%>
+          "expr": "0.5 * (<%= isNaN(width) ? '0' : width %> - (5 - 1) * 50) / 5 - 10 * datum.a.pos"
+        },
+        {
+          "type": "formula",
+          "field": "innerRadius",
+          "expr": "datum.outerRadius - 5"
+        },
+        {
+          "type": "formula",
+          "field": "lineCapDiameter",
+          "expr": "(datum.outerRadius - datum.innerRadius)"
+        },
+        {
+          "type": "formula",
+          "field": "lineCapRadiusPos",
+          "expr": "datum.innerRadius + datum.lineCapDiameter / 2"
+        },
+        {
+          "type": "formula",
+          "field": "labelPos",
+          "expr": "(<%= isNaN(height) ? '0' : height %> - datum.outerRadius * 2) / 4"
+        }
+      ]
+    },
+    {
+      "name": "grouped",
+      "source": "ungrouped",
+      "transform": [
+        {
+          "type": "formula",
+          "field": "group",
+          "expr": "datum.a.group"
+        },
+        {
+          "type": "facet",
+          "groupby": ["group"]
+        }
+      ]
+    },
+    {
+      "name": "legend",
+      "source": "groups",
+      "transform": [
+        {
+          "type": "cross",
+          "with": "countGroups"
+        },
+        {
+          "type": "formula",
+          "field": "posX",
+          "expr": "(<%= isNaN(width) ? '0' : width %> / 3) * datum.a.rank + 11"
+        },
+        {
+          "type": "formula",
+          "field": "posY",
+          "expr": "<%= isNaN(height) ? '0' : height %> - 11"
+        },
+        {
+          "type": "formula",
+          "field": "opacityOuter",
+          "expr": "datum.a.rank === 0 ? 1 : 0.2"
+        },
+        {
+          "type": "formula",
+          "field": "opacityMiddle",
+          "expr": "datum.b.count_group < 2 ? 0 : (datum.a.rank === 1 ? 1 : 0.2)"
+        },
+        {
+          "type": "formula",
+          "field": "opacityInner",
+          "expr": "datum.b.count_group < 3 ? 0 : (datum.a.rank === 2 ? 1 : 0.2)"
+        },
+        {
+          "type": "formula",
+          "field": "label",
+          "expr": "(datum.a.rank === 2 ? 'Inner ring:' : (datum.a.rank === 1 ? (datum.b.count_group === 2 ? 'Inner ring:' : 'Middle ring:') : 'Outer ring:')) + ' ' + datum.a.group"
+        }
+      ]
+    }
+  ],
+  "scales": [
+    {
+      "name": "x",
+      "type": "ordinal",
+      "range": "width",
+      "domain": {"data": "table","field": "label"},
+      "points": true,
+      "padding": 1
+    },
+    {
+      "name": "color",
+      "type": "ordinal",
+      "domain": {"data": "table","field": "label"},
+      "range": [
+        "#2f939c",
+        "#97c9ce",
+        "#001d22",
+        "#f9d031",
+        "#f95e31",
+        "#FCAE98",
+        "#633AE8",
+        "#E4D081",
+        "#00D9C6",
+        "#B9A86C",
+        "#7B0051",
+        "#B685C9",
+        "#076270",
+        "#8ADF70"
+      ]
+    },
+    {
+      "name": "radius",
+      "type": "linear",
+      "domain": [0,100],
+      "range": [0,6.2831853072]
+    }
+  ],
+  "marks": [
+    {
+      "type": "group",
+      "from": {"data": "grouped"},
+      "properties": {
+        "enter": {
+          "width": {"field": {"group": "height"}},
+          "height": {"field": {"group": "height"}}
+        }
+      },
+      "marks": [
+        {
+          "type": "arc",
+          "properties": {
+            "enter": {
+              "x": {"scale": "x","field": "a.label"},
+              "y": {"field": {"group": "height"},"mult": 0.5},
+              "innerRadius": {"field": "innerRadius"},
+              "outerRadius": {"field": "outerRadius"},
+              "startAngle": {"value": 0},
+              "endAngle": {"value": 6.2831853072},
+              "fill": {"field": "a.label","scale": "color"},
+              "opacity": {"value": 0.2}
+            }
+          }
+        },
+        {
+          "type": "arc",
+          "properties": {
+            "enter": {
+              "x": {"scale": "x","field": "a.label"},
+              "y": {"field": {"group": "height"},"mult": 0.5},
+              "innerRadius": {"field": "innerRadius"},
+              "outerRadius": {"field": "outerRadius"},
+              "startAngle": {"value": 0},
+              "endAngle": {"field": "a.percentage","scale": "radius"},
+              "fill": {"field": "a.label","scale": "color"}
+            }
+          }
+        }
+      ]
+    },
+    {
+      "type": "group",
+      "from": {
+        "data": "ungrouped",
+        "transform": [
+          {
+            "type": "formula",
+            "field": "size",
+            "expr": "datum.lineCapDiameter * datum.lineCapDiameter - 10"
+          },
+          {
+            "type": "formula",
+            "field": "endCapAngle",
+            "expr": "scale('radius', datum.a.percentage)"
+          },
+          {
+            "type": "formula",
+            "field": "endCapX",
+            "expr": "cos(datum.endCapAngle - 1.5707963268) * datum.lineCapRadiusPos"
+          },
+          {
+            "type": "formula",
+            "field": "endCapY",
+            "expr": "sin(datum.endCapAngle - 1.5707963268) * datum.lineCapRadiusPos"
+          }
+        ]
+      },
+      "properties": {
+        "enter": {
+          "x": {"scale": "x","field": "a.label"},
+          "y": {"field": {"group": "height"},"mult": 0.5}
+        }
+      },
+      "marks": [
+        {
+          "type": "symbol",
+          "properties": {
+            "enter": {
+              "x": {"value": 0},
+              "y": {
+                "field": {"parent": "lineCapRadiusPos"},
+                "mult": -1
+              },
+              "shape": "circle",
+              "size": {"field": {"parent": "size"}},
+              "fill": {
+                "field": {"parent": "a.label"},
+                "scale": "color"
+              }
+            }
+          }
+        },
+        {
+          "type": "symbol",
+          "properties": {
+            "enter": {
+              "x": {"field": {"parent": "endCapX"}},
+              "y": {"field": {"parent": "endCapY"}},
+              "shape": "circle",
+              "size": {"field": {"parent": "size"}},
+              "fill": {
+                "field": {"parent": "a.label"},
+                "scale": "color"
+              }
+            }
+          }
+        }
+      ]
+    },
+    {
+      "type": "text",
+      "from": {
+        "data": "ungrouped",
+        "transform": [
+          {
+            "type": "cross",
+            "with": "countGroups"
+          },
+          {
+            "type": "formula",
+            "field": "percentagePos",
+            "expr": "300 / 2 + (datum.b.count_group === 2 ? (datum.a.a.pos * 24) : (((datum.a.a.pos - 1) * 24) + 7 + (datum.a.a.pos === 0 ? -2 : 0)))"
+          },
+          {
+            "type": "formula",
+            "field": "percentageSize",
+            "expr": "datum.b.count_group === 2 ? (datum.a.a.pos === 0 ? 24 : 16) : (datum.a.a.pos === 0 ? 24 : (datum.a.a.pos === 1 ? 20 : 16))"
+          }
+        ]
+      },
+      "properties": {
+        "enter": {
+          "x": {"scale": "x","field": "a.a.label"},
+          "y": {"field": "percentagePos"},
+          "font": {"value": "Chalet"},
+          "fontWeight": {"value": "400"},
+          "fontSize": {"field": "percentageSize"},
+          "fill": {"value": "#001d22"},
+          "text": {
+            "template": "{{datum.a.a.percentage|number:'.2f'}}%"
+          },
+          "align": {"value": "center"},
+          "baseline": {"value": "middle"}
+        }
+      }
+    },
+    {
+      "type": "text",
+      "from": {
+        "data": "ungrouped",
+        "transform": [
+          {
+            "type": "filter",
+            "test": "datum.a.pos === 0"
+          }
+        ]
+      },
+      "properties": {
+        "enter": {
+          "x": {"scale": "x","field": "a.label"},
+          "y": {"field": "labelPos"},
+          "font": {"value": "inherit"},
+          "fontWeight": {"value": "300"},
+          "fontSize": {"value": 16},
+          "fill": {"value": "#001d22"},
+          "text": {"field": "label"},
+          "align": {"value": "center"},
+          "baseline": {"value": "middle"}
+        }
+      }
+    },
+    {
+      "type": "arc",
+      "from": {"data": "legend"},
+      "properties": {
+        "enter": {
+          "x": {"field": "posX"},
+          "y": {"field": "posY"},
+          "innerRadius": {"value": 10},
+          "outerRadius": {"value": 8},
+          "startAngle": {"value": 0},
+          "endAngle": {"value": 6.2831853072},
+          "fill": {"value": "#2f939c"},
+          "opacity": {"field": "opacityOuter"}
+        }
+      }
+    },
+    {
+      "type": "arc",
+      "from": {"data": "legend"},
+      "properties": {
+        "enter": {
+          "x": {"field": "posX"},
+          "y": {"field": "posY"},
+          "innerRadius": {"value": 6},
+          "outerRadius": {"value": 4},
+          "startAngle": {"value": 0},
+          "endAngle": {"value": 6.2831853072},
+          "fill": {"value": "#2f939c"},
+          "opacity": {"field": "opacityMiddle"}
+        }
+      }
+    },
+    {
+      "type": "arc",
+      "from": {"data": "legend"},
+      "properties": {
+        "enter": {
+          "x": {"field": "posX"},
+          "y": {"field": "posY"},
+          "innerRadius": {"value": 2},
+          "outerRadius": {"value": 0},
+          "startAngle": {"value": 0},
+          "endAngle": {"value": 6.2831853072},
+          "fill": {"value": "#2f939c"},
+          "opacity": {"field": "opacityInner"}
+        }
+      }
+    },
+    {
+      "type": "text",
+      "from": {"data": "legend"},
+      "properties": {
+        "enter": {
+          "x": {"field": "posX", "offset": 15},
+          "y": {"field": "posY", "offset": 0},
+          "text": {"field": "label"},
+          "font": {"value": "Montserrat"},
+          "fontWeight": {"value": "300"},
+          "fontSize": {"value": 13},
+          "fill": {"value": "#001d22"},
+          "baseline": {"value": "middle"}
+        }
+      }
+    }
+  ]
+}

--- a/app/assets/javascripts/views/data_portal/ChartWidgetView.js
+++ b/app/assets/javascripts/views/data_portal/ChartWidgetView.js
@@ -31,6 +31,8 @@
       // List of the indicators used for the comparison
       // The format of each of them is:
       // { id: string, year: number, iso: string, filters: { id: string, name: string, options: string[] }[] }
+      // NOTE: the filters attribute do not contain the filters set for the whole portal but instead, only
+      // the filters used for the comparation
       compareIndicators: null
     },
 
@@ -146,25 +148,17 @@
         this.options.analysisIndicator = null;
       }
 
-      // TODO: add the real logic
-      if (!this.options.compareIndicators) {
-        this.options.compareIndicators = [];
-      }
-
-      this.options.compareIndicators.push({
-        id: this.options.indicator.id,
-        year: 2006,
-        iso: 'UGA',
-        filters: []
-      },
-      {
-        id: this.options.indicator.id,
-        year: 2010,
-        iso: 'GHA',
-        filters: []
+      new App.Component.ModalChartCompare({
+        indicator: this.options.indicator,
+        iso: this.options.iso,
+        year: this.options.year,
+        compareIndicators: this.options.compareIndicators,
+        continueCallback: function (compareIndicators) {
+          this.options.compareIndicators = compareIndicators;
+          this._fetchData();
+        }.bind(this),
+        stopCompareCallback: this._onStopCompare.bind(this)
       });
-
-      this._fetchData();
     },
 
     /**

--- a/app/assets/javascripts/views/data_portal/compare/CountryYearView.js
+++ b/app/assets/javascripts/views/data_portal/compare/CountryYearView.js
@@ -1,0 +1,204 @@
+(function (App) {
+
+  var Collection = Backbone.Collection.extend({
+
+    comparator: 'name',
+
+    initialize: function (attributes, options) {
+      this.options = _.extend({}, options);
+    },
+
+    url: function () {
+      return API_URL + '/country/';
+    },
+
+    parse: function (data) {
+      return data.map(function (row) {
+        return {
+          name: row.name,
+          iso: row.iso,
+          years: row.year.map(function (years) {
+            return {
+              value: years.year,
+              active: this.options.iso === row.iso && this.options.year === years.year,
+              disabled: this.options.iso === row.iso && this.options.year === years.year
+            };
+          }, this)
+        };
+      }, this);
+    }
+
+  });
+
+  App.View.CountryYearView = Backbone.View.extend({
+
+    template: JST['templates/data_portal/compare/country-year'],
+
+    defaults: {
+      // ISO of the country
+      iso: null,
+      // Current year of the portal
+      year: null,
+      // The indicator being compared
+      indicator: null,
+      // Number of options the user can select at max
+      optionsLimit: 3,
+      // List of the indicators used for the comparison
+      // The format of each of them is:
+      // { id: string, year: number, iso: string, filters: { id: string, name: string, options: string[] }[] }
+      compareIndicators: []
+    },
+
+    events: {
+      'click .js-retry-compare': '_fetchData',
+      'click .js-year': '_onClickYear'
+    },
+
+    initialize: function (options) {
+      this.options = _.extend({}, this.defaults, options);
+
+      // We copy the array to avoid mutations
+      this.options.compareIndicators = Array.prototype.slice.call(this.options.compareIndicators || []);
+
+      this.collection = new Collection({}, {
+        iso: this.options.iso,
+        year: this.options.year
+      });
+      this._fetchData();
+    },
+
+    /**
+     * Event handler executed when the user interacts with a checkbox
+     * @param {Event} e event
+     */
+    _onClickYear: function (e) {
+      var checkbox = e.target;
+      var iso = checkbox.dataset.iso;
+      var year = +checkbox.value;
+
+      // If the user clicks the disabled checkbox, we don't do anything
+      if (checkbox.disabled) return;
+
+      if (checkbox.checked) { // Just being checked
+        if (!this._canSelectOption()) checkbox.checked = false;
+        else {
+          this._addCompareItem(iso, year);
+        }
+      } else {
+        this._removeCompareItem(iso, year);
+      }
+    },
+
+    /**
+     * Add an item to this.options.compareIndicators
+     * @param {string} iso ISO of the country
+     * @param {number} year
+     */
+    _addCompareItem: function (iso, year) {
+      this.options.compareIndicators.push({
+        id: this.options.indicator.id,
+        iso: iso,
+        year: year,
+        filters: []
+      });
+    },
+
+    /**
+     * Remove an item to this.options.compareIndicators
+     * @param {string} iso ISO of the country
+     * @param {number} year
+     */
+    _removeCompareItem: function (iso, year) {
+      var compareItemIndex = _.findIndex(this.options.compareIndicators, { iso: iso });
+      this.options.compareIndicators.splice(compareItemIndex, 1);
+    },
+
+    /**
+     * Return whether the user can select another option
+     * @return {boolean}
+     */
+    _canSelectOption: function () {
+      return this.options.compareIndicators.length + 1 < this.options.optionsLimit;
+    },
+
+    /**
+     * Fetch the list of countries and years and render the view
+     */
+    _fetchData: function () {
+      this._showLoader();
+
+      this.collection.fetch()
+        .done(this.render.bind(this))
+        .fail(this.renderError.bind(this))
+        .always(this._hideLoader.bind(this));
+    },
+
+    /**
+     * Show the spinning loader
+     * NOTE: also empties the container
+     */
+    _showLoader: function () {
+      this.el.innerHTML = '';
+      this.el.classList.add('c-spinning-loader');
+    },
+
+    /**
+     * Hide the spinning loader
+     */
+    _hideLoader: function () {
+      this.el.classList.remove('c-spinning-loader');
+    },
+
+    /**
+     * Return the data associated with the tab
+     * @return { { id: string, year: number, iso: string, filters: {}[] } }
+     */
+    getData: function () {
+      return this.options.compareIndicators;
+    },
+
+    /**
+     * Return the data in a format adapted for the render function
+     * @return { { name: string, iso: string, years: { value: number, active: boolean, disabled: boolean }[] }[] }
+     */
+    _getDataForRender: function () {
+      return this.collection.toJSON()
+        .map(function (country) {
+          var activeYears = this.options.compareIndicators
+            .filter(function (compareIndicator) { return compareIndicator.iso === country.iso })
+            .reduce(function (res, compareIndicator) { return res.concat([compareIndicator.year]); }, []);
+
+          return _.extend({}, country, {
+            years: country.years.map(function (year) {
+              return _.extend({}, year, {
+                // The year that is disabled is the year selected for the whole portal
+                // so it should always stay active
+                active: activeYears.indexOf(year.value) !== -1 || year.disabled
+              });
+            })
+          });
+
+        }, this)
+    },
+
+    render: function () {
+      this.el.innerHTML = this.template({
+        countries: this._getDataForRender()
+      });
+
+      this.setElement(this.el);
+
+      return this;
+    },
+
+    renderError: function () {
+      this.el.innerHTML = '<p class="loading-error">' +
+        'Unable to load the compare options' +
+        '<button type="button" class="c-button -retry js-retry-compare">Retry</button>' +
+        '</p>';
+
+      this.setElement(this.el);
+    }
+
+  });
+}.call(this, this.App));

--- a/app/assets/javascripts/views/data_portal/compare/JurisdictionView.js
+++ b/app/assets/javascripts/views/data_portal/compare/JurisdictionView.js
@@ -1,0 +1,194 @@
+(function (App) {
+
+  App.View.JurisdictionView = Backbone.View.extend({
+
+    template: JST['templates/data_portal/compare/jurisdiction'],
+
+    defaults: {
+      // ISO of the country
+      iso: null,
+      // Current year of the portal
+      year: null,
+      // The indicator being compared
+      indicator: null,
+      // Number of options the user can select at max
+      optionsLimit: 3,
+      // List of the indicators used for the comparison
+      // The format of each of them is:
+      // { id: string, year: number, iso: string, filters: { id: string, name: string, options: string[] }[] }
+      compareIndicators: []
+    },
+
+    events: {
+      'click .js-retry-compare': '_fetchData',
+      'click .js-jurisdiction': '_onClickJurisdiction'
+    },
+
+    initialize: function (options) {
+      this.options = _.extend({}, this.defaults, options);
+
+      // We copy the array to avoid mutations
+      this.options.compareIndicators = Array.prototype.slice.call(this.options.compareIndicators || []);
+
+      this._fetchData();
+    },
+
+    /**
+     * Event handler executed when the user interacts with a checkbox
+     * @param {Event} e event
+     */
+    _onClickJurisdiction: function (e) {
+      var checkbox = e.target;
+
+      if (checkbox.checked) { // Just being checked
+        if (!this._canSelectOption()) checkbox.checked = false;
+        else {
+          this._addCompareItem(checkbox.value);
+        }
+      } else {
+        this._removeCompareItem(checkbox.value);
+      }
+    },
+
+    /**
+     * Add an item to this.options.compareIndicators
+     * @param {string} juridication name of the jurisdiction
+     */
+    _addCompareItem: function (jurisdiction) {
+      this.options.compareIndicators.push({
+        id: this.options.indicator.id,
+        iso: this.options.iso,
+        year: this.options.year,
+        filters: [{
+          id: 'jurisdiction',
+          name: 'jurisdiction',
+          options: [jurisdiction]
+        }]
+      });
+    },
+
+    /**
+     * Remove an item to this.options.compareIndicators
+     * @param {string} jurisdiction name of the jurisdiction
+     */
+    _removeCompareItem: function (jurisdiction) {
+      var compareItemIndex = _.findIndex(this.options.compareIndicators, function (compareIndicator) {
+        return compareIndicator.filters.length
+          && compareIndicator.filters[0].options.length
+          && compareIndicator.filters[0].options[0] === jurisdiction;
+      }, this);
+      this.options.compareIndicators.splice(compareItemIndex, 1);
+    },
+
+    /**
+     * Return whether the user can select another option
+     * @return {boolean}
+     */
+    _canSelectOption: function () {
+      return this.options.compareIndicators.length + 1 < this.options.optionsLimit;
+    },
+
+    /**
+     * Fetch the list of countries and years and render the view
+     */
+    _fetchData: function () {
+      this._showLoader();
+
+      this.model = new App.Model.IndicatorModel({}, {
+        id: 'jurisdiction',
+        iso: this.options.iso,
+        year: this.options.year,
+        filters: [] // The filters shouldn't be needed to retrieve the juridications
+      });
+
+      this.model.fetch()
+        .done(this.render.bind(this))
+        .fail(this.renderError.bind(this))
+        .always(this._hideLoader.bind(this));
+    },
+
+    /**
+     * Show the spinning loader
+     * NOTE: also empties the container
+     */
+    _showLoader: function () {
+      this.el.innerHTML = '';
+      this.el.classList.add('c-spinning-loader');
+    },
+
+    /**
+     * Hide the spinning loader
+     */
+    _hideLoader: function () {
+      this.el.classList.remove('c-spinning-loader');
+    },
+
+    /**
+     * Return the data associated with the tab
+     * @return { { id: string, year: number, iso: string, filters: {}[] } }
+     */
+    getData: function () {
+      return this.options.compareIndicators;
+    },
+
+    /**
+     * Return the data in a format adapted for the render function
+     * @return { { name: string, active: boolean }[] }[] }
+     */
+    _getDataForRender: function () {
+      var res = this.model.get('data');
+
+      // We copy the array to avoid mutations
+      res = Array.prototype.slice.call(res);
+
+      var activeJuridictions = this.options.compareIndicators
+        .map(function (compareIndicator) {
+          return compareIndicator.filters.length
+            && compareIndicator.filters[0]
+            && compareIndicator.filters[0].options.length
+            && compareIndicator.filters[0].options[0];
+        });
+
+      res = res.map(function (row) {
+        return {
+          name: row.label,
+          active: activeJuridictions.indexOf(row.label) !== -1
+        };
+      });
+
+      var isAllOptionActive = !!this.options.compareIndicators
+        .filter(function (compareIndicator) {
+          return !compareIndicator.filters.length;
+        }).length;
+
+      // We add the "All" option, by default active
+      res.unshift({
+        name: 'All',
+        active: true,
+        disabled: true
+      });
+
+      return res;
+    },
+
+    render: function () {
+      this.el.innerHTML = this.template({
+        jurisdictions: this._getDataForRender()
+      });
+
+      this.setElement(this.el);
+
+      return this;
+    },
+
+    renderError: function () {
+      this.el.innerHTML = '<p class="loading-error">' +
+        'Unable to load the compare options' +
+        '<button type="button" class="c-button -retry js-retry-compare">Retry</button>' +
+        '</p>';
+
+      this.setElement(this.el);
+    }
+
+  });
+}.call(this, this.App));

--- a/app/assets/stylesheets/components/data-portal/c-modal-chart-compare.scss
+++ b/app/assets/stylesheets/components/data-portal/c-modal-chart-compare.scss
@@ -1,59 +1,27 @@
 .c-modal-chart-compare {
-  // padding: 40px;
+  height: 450px;
+  padding: 30px;
+  overflow-y: auto;
+  -webkit-overflow-scrolling: touch;
 
   > .header {
-    padding: 30px 30px 0;
-    background-color: rgba($color-1, .1);
-
     span {
       color: $color-1;
     }
   }
 
-  > .compare-tabs {
-    display: flex;
-    align-items: center;
-    padding: 30px 30px 15px;
-    background-color: rgba($color-1, .1);
-
-    .tab {
-      color: $color-1;
-      font-family: $font-family-1;
-      font-size: $font-size-xs;
-      cursor: pointer;
-
-      &:not(:last-child) {
-        margin: 0 30px 0 0;
-      }
-
-      &[aria-selected='true'] {
-        position: relative;
-        color: $color-5;
-
-        &::after {
-          display: inline-block;
-          position: absolute;
-          bottom: -15px;
-          left: 0;
-          width: 100%;
-          height: 6px;
-
-          outline: none;
-          background-color: $color-1;
-          content: '';
-        }
-      }
-    }
+  > button {
+    margin: 25px 0;
   }
 
   > .compare-container {
-    height: 450px;
-    padding: 30px;
-    overflow-y: auto;
-    -webkit-overflow-scrolling: touch;
 
-    button {
-      margin-bottom: 25px;
+    &:not(:empty) {
+      margin-top: 15px;
+    }
+
+    &.c-spinning-loader {
+      min-height: 100px;
     }
 
     .loading-error {

--- a/app/assets/stylesheets/components/data-portal/c-modal-chart-compare.scss
+++ b/app/assets/stylesheets/components/data-portal/c-modal-chart-compare.scss
@@ -93,4 +93,15 @@
       }
     }
   }
+
+  .jurisdiction {
+    .jurisdications-list {
+      display: flex;
+      flex-wrap: wrap;
+
+      > li {
+        flex-basis: 33.33%;
+      }
+    }
+  }
 }

--- a/app/assets/stylesheets/components/data-portal/c-modal-chart-compare.scss
+++ b/app/assets/stylesheets/components/data-portal/c-modal-chart-compare.scss
@@ -1,0 +1,96 @@
+.c-modal-chart-compare {
+  // padding: 40px;
+
+  > .header {
+    padding: 30px 30px 0;
+    background-color: rgba($color-1, .1);
+
+    span {
+      color: $color-1;
+    }
+  }
+
+  > .compare-tabs {
+    display: flex;
+    align-items: center;
+    padding: 30px 30px 15px;
+    background-color: rgba($color-1, .1);
+
+    .tab {
+      color: $color-1;
+      font-family: $font-family-1;
+      font-size: $font-size-xs;
+      cursor: pointer;
+
+      &:not(:last-child) {
+        margin: 0 30px 0 0;
+      }
+
+      &[aria-selected='true'] {
+        position: relative;
+        color: $color-5;
+
+        &::after {
+          display: inline-block;
+          position: absolute;
+          bottom: -15px;
+          left: 0;
+          width: 100%;
+          height: 6px;
+
+          outline: none;
+          background-color: $color-1;
+          content: '';
+        }
+      }
+    }
+  }
+
+  > .compare-container {
+    height: 450px;
+    padding: 30px;
+    overflow-y: auto;
+    -webkit-overflow-scrolling: touch;
+
+    button {
+      margin-bottom: 25px;
+    }
+
+    .loading-error {
+      position: absolute;
+      top: 50%;
+      left: 50%;
+      transform: translate(-50%, -50%);
+      color: $color-1;
+      font-family: $font-family-2;
+      text-align: center;
+
+      .c-button {
+        display: block;
+        margin: 30px auto 0;
+      }
+    }
+  }
+
+  .country-year {
+    .countries-list {
+      display: flex;
+      flex-wrap: wrap;
+      justify-content: space-between;
+
+      > div {
+        flex-basis: calc(50% - 15px);
+
+        > .years-list {
+          display: flex;
+          flex-wrap: wrap;
+          margin: 10px 0 20px;
+
+          > li {
+            flex-basis: 33.33%;
+          }
+        }
+      }
+    }
+  }
+}

--- a/app/assets/stylesheets/components/shared/c-checkbox.scss
+++ b/app/assets/stylesheets/components/shared/c-checkbox.scss
@@ -19,6 +19,10 @@ $checkbox-radio-button: 10px;
         box-shadow: 0 2px 3px 0 rgba($color-6, .15);
       }
     }
+
+    &:disabled + label {
+      opacity: .4;
+    }
   }
 
   label {


### PR DESCRIPTION
This PR brings the comparison mode to the indicators. The user as the possibility to compare any strand indicator with the data of the same indicator:
- for other countries and years
- for other jurisdictions

_NOTE: These two options are exclusive._

Within a widget, only three datasets can be compared: the default data of the indicator and two choices made by the user.

The compare mode – as the analysis mode – doesn't let the user change the graph or select another mode at the same time.

<img width="1086" alt="screen shot 2017-03-24 at 12 15 46" src="https://cloud.githubusercontent.com/assets/6073968/24293976/50989a56-108c-11e7-9f10-9ce4f680c866.png">
