### PR TITLE
Implement the jurisdiction filter

### DIFF
--- a/app/assets/javascripts/components/data_portal/modals/modal-chart-compare.js
+++ b/app/assets/javascripts/components/data_portal/modals/modal-chart-compare.js
@@ -17,9 +17,13 @@
       iso: null,
       // Current year of the portal
       year: null,
+      // Current filters of the portal
+      filters: [],
       // List of the indicators used for the comparison
       // See "compareIndicators" in App.View.ChartWidgetView for the format
       compareIndicators: [],
+      // Whether the user can compare the indicator with a different country/year
+      canCompareCountries: true,
       // Callback executed when the user presses the "Done" button
       // The callback gets passed the name of the selected chart
       continueCallback: function () {},
@@ -50,18 +54,20 @@
         {
           id: 'country-year',
           name: 'Country and year',
-          view: App.View.CountryYearView
+          view: App.View.CountryYearView,
+          available: this.options.canCompareCountries
         },
         {
           id: 'jurisdiction',
           name: 'Jurisdiction in ' + App.Helper.Indicators.COUNTRIES[this.options.iso] + ' in ' + this.options.year,
-          view: App.View.JurisdictionView
+          view: App.View.JurisdictionView,
+          available: true
         }
       ];
 
-      // If the compare indicators the view gets passed are jurisdiction indicators
-      // then the default tab is the second
-      if (this._isJurisdictionsCompareIndicators()) {
+      // If the compare indicators the view gets passed are jurisdiction indicators or
+      // the first tab is unavailable, then the default tab is the second
+      if (this._isJurisdictionsCompareIndicators() || !this.options.canCompareCountries) {
         this.options._currentTab = 1;
       } else if (this.options.compareIndicators && this.options.compareIndicators.length) {
         this.options._currentTab = 0;
@@ -120,6 +126,7 @@
         el: this.$el.find('.js-container-' + tab.id),
         iso: this.options.iso,
         year: this.options.year,
+        filters: this.options.filters,
         indicator: this.options.indicator,
         compareIndicators: this.options.compareIndicators
       });

--- a/app/assets/javascripts/models/data_portal/ChartWidgetModel.js
+++ b/app/assets/javascripts/models/data_portal/ChartWidgetModel.js
@@ -44,7 +44,12 @@
               id: compareIndicator.id,
               iso: compareIndicator.iso,
               year: compareIndicator.year,
-              filters: (this.options.filters || []).concat(compareIndicator.filters)
+              filters: (this.options.filters || [])
+                // The partial indicators can't be filtered twice by jurisdiction
+                .filter(function (filter) {
+                  return filter.id !== 'jurisdiction';
+                })
+                .concat(compareIndicator.filters)
             }
           )
         }, this);
@@ -159,7 +164,11 @@
      */
     _getCompareGroupName: function (model) {
       if (this._isJurisdictionCompare()) {
-        return model !== this.indicatorModel ? this._getJurisdictionName(model) : 'All jurisdictions';
+        var jurisdictionFilter = _.findWhere(this.options.filters, { id: 'jurisdiction' });
+
+        return model !== this.indicatorModel
+          ? this._getJurisdictionName(model)
+          : (jurisdictionFilter ? jurisdictionFilter.options[0] : 'All jurisdictions');
       } else {
         return App.Helper.Indicators.COUNTRIES[model.options.iso] + ' ' + model.options.year;
       }

--- a/app/assets/javascripts/templates/data_portal/filters/select-context.jst.ejs
+++ b/app/assets/javascripts/templates/data_portal/filters/select-context.jst.ejs
@@ -10,4 +10,15 @@
       </li>
     <% }) %>
   </ul>
+  <h3>Select jurisdiction</h3>
+  <ul>
+    <% jurisdictions.forEach(function (jurisdiction) { %>
+      <li>
+        <div class="c-radio-button">
+          <input type="radio" id="jurisdiction-<%= jurisdiction.value %>" name="jurisdiction" value="<%= jurisdiction.value %>" class="js-jurisdiction" <%= jurisdiction.active ? 'checked' : '' %> />
+          <label for="jurisdiction-<%= jurisdiction.value %>"><%= jurisdiction.value %></label>
+        </div>
+      </li>
+    <% }) %>
+  </ul>
 </div>

--- a/app/assets/javascripts/templates/data_portal/header.jst.ejs
+++ b/app/assets/javascripts/templates/data_portal/header.jst.ejs
@@ -53,7 +53,7 @@
     <div class="row">
       <div class="grid-s-12 grid-l-7">
         <div class="l-data-range">
-          <span class="c-tag">All jurisdictions</span>
+          <span class="c-tag"><%= jurisdiction %></span>
           in
           <span class="c-tag js-year"><%= year %></span>
           <!-- <p>Showing data about <span class="c-tag">individuals</span> and

--- a/app/assets/javascripts/templates/data_portal/modals/modal-chart-compare.jst.ejs
+++ b/app/assets/javascripts/templates/data_portal/modals/modal-chart-compare.jst.ejs
@@ -5,7 +5,7 @@
   <button class="c-button -mini js-clear-comparison">Clear comparison</button>
   <% tabs.forEach(function (tab, index) { %>
     <div class="c-radio-button">
-      <input type="radio" name="compare" id="compare-<%= tab.id %>" class="js-compare" value="<%= tab.id %>" <%= index === currentTab ? 'checked' : '' %>>
+      <input type="radio" name="compare" id="compare-<%= tab.id %>" class="js-compare" value="<%= tab.id %>" <%= index === currentTab ? 'checked' : '' %> <%= !tab.available ? 'disabled' : '' %>>
       <label for="compare-<%= tab.id %>"><%= tab.name %></label>
     </div>
     <div class="compare-container js-container js-container-<%= tab.id %>"></div>

--- a/app/assets/javascripts/views/data_portal/ChartWidgetView.js
+++ b/app/assets/javascripts/views/data_portal/ChartWidgetView.js
@@ -141,19 +141,22 @@
      * Event handler for when the user clicks the compare button
      */
     _onCompare: function () {
-      // TODO: move the next block in the continue callback
-      // If the analysis is active, we stop it
-      if (this.options.analysisIndicator) {
-        this.options.chart = null;
-        this.options.analysisIndicator = null;
-      }
+      var jurisdictionFilter = _.findWhere(this.options.filters, { id: 'jurisdiction' });
 
       new App.Component.ModalChartCompare({
         indicator: this.options.indicator,
         iso: this.options.iso,
         year: this.options.year,
+        filters: this.options.filters,
         compareIndicators: this.options.compareIndicators,
+        canCompareCountries: !jurisdictionFilter,
         continueCallback: function (compareIndicators) {
+          // If the analysis is active, we stop it
+          if (this.options.analysisIndicator) {
+            this.options.chart = null;
+            this.options.analysisIndicator = null;
+          }
+
           this.options.compareIndicators = compareIndicators;
           this._fetchData();
         }.bind(this),

--- a/app/assets/javascripts/views/data_portal/FiltersIndicatorsModal.js
+++ b/app/assets/javascripts/views/data_portal/FiltersIndicatorsModal.js
@@ -20,6 +20,8 @@
       indicators: [],
       // List of filters currently applied
       filters: [],
+      // Jurisdiction currently used as a filter
+      jurisdiction: null,
       // Index of the current tab
       _currentTab: 0,
       // List of the tabs
@@ -30,7 +32,9 @@
       // List of selected filters in the modal
       _selectedFilters: null,
       // Selected year in the modal
-      _selectedYear: null
+      _selectedYear: null,
+      // Selected jurisdiction in the modal
+      _selectedJurisdiction: null
     },
 
     events: function () {
@@ -102,13 +106,18 @@
         ? this.options._selectedYear
         : this.options.year;
 
+      var jurisdiction = this.options._selectedJurisdiction
+        ? this.options._selectedJurisdiction
+        : this.options.jurisdiction;
+
       var View = this.options._tabs[tabIndex].view;
       this.filterView = new View({
         el: this.$el.find('.js-filters-container'),
         iso: this.options.iso,
         year: year,
         indicators: indicators,
-        filters: filters
+        filters: filters,
+        jurisdiction: jurisdiction
       });
     },
 
@@ -117,30 +126,34 @@
      */
     _saveCurrentTabData: function () {
       var tab = this.options._tabs[this.options._currentTab];
+      var data = this.filterView.getData();
 
-      var attribute;
       switch (tab.id) {
         case 'apply-filters':
-          attribute = '_selectedFilters';
+          this.options._selectedFilters = data;
           break;
 
         case 'select-context':
-          attribute = '_selectedYear';
+          this.options._selectedYear = data.year;
+          this.options._selectedJurisdiction = data.jurisdiction;
           break;
 
         default:
-          attribute = '_selectedIndicators';
+          this.options._selectedIndicators = data;
       }
-
-      var data = this.filterView.getData();
-      this.options[attribute] = data;
     },
 
     _onClickDone: function () {
       // We save the data of the current tab
       this._saveCurrentTabData();
 
-      this.options.continueCallback(this.options._selectedIndicators, this.options._selectedFilters, this.options._selectedYear);
+      this.options.continueCallback(
+        this.options._selectedIndicators,
+        this.options._selectedFilters,
+        this.options._selectedYear,
+        this.options._selectedJurisdiction
+      );
+
       this.onCloseModal();
     },
 

--- a/app/assets/javascripts/views/data_portal/compare/JurisdictionView.js
+++ b/app/assets/javascripts/views/data_portal/compare/JurisdictionView.js
@@ -9,6 +9,8 @@
       iso: null,
       // Current year of the portal
       year: null,
+      // Current filters of the portal
+      filters: [],
       // The indicator being compared
       indicator: null,
       // Number of options the user can select at max
@@ -141,6 +143,8 @@
       // We copy the array to avoid mutations
       res = Array.prototype.slice.call(res);
 
+      var jurisdicationFilter = _.findWhere(this.options.filters, { id: 'jurisdiction' });
+
       var activeJuridictions = this.options.compareIndicators
         .map(function (compareIndicator) {
           return compareIndicator.filters.length
@@ -152,19 +156,18 @@
       res = res.map(function (row) {
         return {
           name: row.label,
-          active: activeJuridictions.indexOf(row.label) !== -1
+          active: jurisdicationFilter && row.label === jurisdicationFilter.options[0]
+            || activeJuridictions.indexOf(row.label) !== -1,
+          disabled: jurisdicationFilter
+            ? row.label === jurisdicationFilter.options[0]
+            : false
         };
       });
-
-      var isAllOptionActive = !!this.options.compareIndicators
-        .filter(function (compareIndicator) {
-          return !compareIndicator.filters.length;
-        }).length;
 
       // We add the "All" option, by default active
       res.unshift({
         name: 'All',
-        active: true,
+        active: !jurisdicationFilter,
         disabled: true
       });
 


### PR DESCRIPTION
This PR adds a new filter to the "context" tab of the "customise" modal: jurisdiction.

<img width="912" alt="Screenshot of the jurisdiction options in the modal" src="https://cloud.githubusercontent.com/assets/6073968/24351675/9352019e-12de-11e7-9d7f-9b271f7969c7.png">

NOTE: Once the user has filtered by jurisdiction, the indicators can't be compared with other countries/years.

[Pivotal task](https://www.pivotaltracker.com/story/show/141321355)