### PR TITLE
Implement a warning tooltip for the widgets

### DIFF
--- a/app/assets/javascripts/templates/data_portal/widget-warning-tooltip.jst.ejs
+++ b/app/assets/javascripts/templates/data_portal/widget-warning-tooltip.jst.ejs
@@ -1,0 +1,8 @@
+<div class="c-widget-warning-tooltip">
+  <h3><%= title %></h3>
+  <p><%= description %></p>
+  <div class="buttons">
+    <button class="c-button -mini js-cancel">Cancel</button>
+    <button class="c-button -mini js-continue">Continue</button>
+  </div>
+</div>

--- a/app/assets/javascripts/views/data_portal/ChartWidgetView.js
+++ b/app/assets/javascripts/views/data_portal/ChartWidgetView.js
@@ -76,56 +76,55 @@
      * Event handler for when the user clicks the change button
      */
     _onChange: function () {
-      // We retrieve the list of all the charts that can be built with vega
-      var charts = App.Helper.ChartConfig
-        .filter(function (chart) {
-          return chart.visible !== false;
-        })
-        .map(function(chart) {
-          return {
-            name: chart.name,
-            available: false,
-            selected: this.options.chart === chart.name
-          };
-        }, this);
+      var deferred = $.Deferred();
 
-      // We update the object to tell which ones are available with the current
-      // dataset
-      this._getAvailableCharts().forEach(function (availableChart) {
-        var chart = _.findWhere(charts, { name: availableChart });
-        if (chart) chart.available = true;
-      });
+      // If the analysis or comparison is active, we display ask the user to confirm
+      // their choice
+      if (this.options.compareIndicators || this.options.analysisIndicator) {
+        new App.View.WidgetWarningTooltipView({
+          refElem: this.el.querySelector('.js-change'),
+          direction: 'top',
+          description: 'The chart selection isn\'t compatible with the '
+            + (this.options.compareIndicators ? 'compare' : 'analysis')
+            + ' mode. You will loose the current configuration.',
+          continueCallback: function () {
+            this.remove();
+            deferred.resolve();
+          },
+          cancelCallback: function () { this.remove(); }
+        });
+      } else {
+        deferred.resolve();
+      }
 
-      // We instantiate the modal
-      new App.Component.ModalChartSelector({
-        charts: charts,
-        continueCallback: this._onChangeChart.bind(this)
-      });
+
+      deferred.done(this._openModalChartSelector.bind(this));
     },
 
     /**
      * Event handler for when the user clicks the analyze button
      */
     _onAnalyze: function () {
-      var nonStrandIndicators = this.options.indicators.filter(function (indicator) {
-        return indicator.category !== App.Helper.Indicators.CATEGORIES.STRAND;
-      });
+      var deferred = $.Deferred();
 
-      new App.Component.ModalChartAnalysis({
-        indicators: nonStrandIndicators,
-        selectedIndicatorId: this.options.analysisIndicator,
-        continueCallback: function (indicatorId) {
-          // If the comparison is active, we stop it
-          if (this.options.compareIndicators) {
-            this.options.chart = null;
-            this.options.compareIndicators = null;
-          }
+      // If the comparison is active, we display ask the user to confirm
+      // their choice
+      if (this.options.compareIndicators) {
+        new App.View.WidgetWarningTooltipView({
+          refElem: this.el.querySelector('.js-analyze'),
+          direction: 'top',
+          description: 'The analysis mode isn\'t compatible with the compare one. You will loose the current configuration.',
+          continueCallback: function () {
+            this.remove();
+            deferred.resolve();
+          },
+          cancelCallback: function () { this.remove(); }
+        });
+      } else {
+        deferred.resolve();
+      }
 
-          this.options.analysisIndicator = indicatorId;
-          this._fetchData();
-        }.bind(this),
-        stopAnalysisCallback: this._onStopAnalyze.bind(this)
-      });
+      deferred.done(this._openModalChartAnalysis.bind(this));
     },
 
     /**
@@ -141,27 +140,26 @@
      * Event handler for when the user clicks the compare button
      */
     _onCompare: function () {
-      var jurisdictionFilter = _.findWhere(this.options.filters, { id: 'jurisdiction' });
+      var deferred = $.Deferred();
 
-      new App.Component.ModalChartCompare({
-        indicator: this.options.indicator,
-        iso: this.options.iso,
-        year: this.options.year,
-        filters: this.options.filters,
-        compareIndicators: this.options.compareIndicators,
-        canCompareCountries: !jurisdictionFilter,
-        continueCallback: function (compareIndicators) {
-          // If the analysis is active, we stop it
-          if (this.options.analysisIndicator) {
-            this.options.chart = null;
-            this.options.analysisIndicator = null;
-          }
+      // If the analysis is active, we display ask the user to confirm
+      // their choice
+      if (this.options.analysisIndicator) {
+        new App.View.WidgetWarningTooltipView({
+          refElem: this.el.querySelector('.js-compare'),
+          direction: 'top',
+          description: 'The compare mode isn\'t compatible with the analysis one. You will loose the current configuration.',
+          continueCallback: function () {
+            this.remove();
+            deferred.resolve();
+          },
+          cancelCallback: function () { this.remove(); }
+        });
+      } else {
+        deferred.resolve();
+      }
 
-          this.options.compareIndicators = compareIndicators;
-          this._fetchData();
-        }.bind(this),
-        stopCompareCallback: this._onStopCompare.bind(this)
-      });
+      deferred.done(this._openModalChartCompare.bind(this));
     },
 
     /**
@@ -221,6 +219,89 @@
       if (!this.tooltip) return;
       this.tooltip.remove();
       this.tooltip = null;
+    },
+
+    /**
+     * Open the modal for the chart comparison
+     */
+    _openModalChartCompare: function () {
+      var jurisdictionFilter = _.findWhere(this.options.filters, { id: 'jurisdiction' });
+
+      new App.Component.ModalChartCompare({
+        indicator: this.options.indicator,
+        iso: this.options.iso,
+        year: this.options.year,
+        filters: this.options.filters,
+        compareIndicators: this.options.compareIndicators,
+        canCompareCountries: !jurisdictionFilter,
+        continueCallback: function (compareIndicators) {
+          // If the analysis is active, we stop it
+          if (this.options.analysisIndicator) {
+            this.options.chart = null;
+            this.options.analysisIndicator = null;
+          }
+
+          this.options.compareIndicators = compareIndicators;
+          this._fetchData();
+        }.bind(this),
+        stopCompareCallback: this._onStopCompare.bind(this)
+      });
+    },
+
+    /**
+     * Open the modal for the chart analysis
+     */
+    _openModalChartAnalysis: function () {
+      var nonStrandIndicators = this.options.indicators.filter(function (indicator) {
+        return indicator.category !== App.Helper.Indicators.CATEGORIES.STRAND;
+      });
+
+      new App.Component.ModalChartAnalysis({
+        indicators: nonStrandIndicators,
+        selectedIndicatorId: this.options.analysisIndicator,
+        continueCallback: function (indicatorId) {
+          // If the comparison is active, we stop it
+          if (this.options.compareIndicators) {
+            this.options.chart = null;
+            this.options.compareIndicators = null;
+          }
+
+          this.options.analysisIndicator = indicatorId;
+          this._fetchData();
+        }.bind(this),
+        stopAnalysisCallback: this._onStopAnalyze.bind(this)
+      });
+    },
+
+    /**
+     * Opent the modal for the chart selection
+     */
+    _openModalChartSelector: function () {
+      // We retrieve the list of all the charts that can be built with vega
+      var charts = App.Helper.ChartConfig
+        .filter(function (chart) {
+          return chart.visible !== false;
+        })
+        .map(function(chart) {
+          return {
+            name: chart.name,
+            available: false,
+            selected: this.options.chart === chart.name
+          };
+        }, this);
+
+      // We update the object to tell which ones are available with the current
+      // dataset
+      this._getAvailableCharts().forEach(function (availableChart) {
+        var chart = _.findWhere(charts, { name: availableChart });
+        if (chart) chart.available = true;
+      });
+
+      // We instantiate the modal
+      new App.Component.ModalChartSelector({
+        charts: charts,
+        continueCallback: this._onChangeChart.bind(this)
+      });
     },
 
     /**

--- a/app/assets/javascripts/views/data_portal/WidgetWarningTooltipView.js
+++ b/app/assets/javascripts/views/data_portal/WidgetWarningTooltipView.js
@@ -1,0 +1,69 @@
+(function (App) {
+  App.View.WidgetWarningTooltipView = App.Component.Tooltip.extend({
+
+    template: JST['templates/data_portal/widget-warning-tooltip'],
+
+    // The default parameters will be merged with the ones of
+    // App.Component.Tooltip
+    defaults: {
+      // Title of the tooltip
+      title: 'Are you sure you want to continue?',
+      // Description of the tooltip
+      description: '',
+      // Offset between the ref element and the tip of the tooltip
+      offset: 5,
+      // Callback executed when the user clicks the continue button
+      continueCallback: function () {},
+      // Callback executed when the user clicks the cancel button
+      cancelCallback: function () {}
+    },
+
+    // We override the default events
+    events: {
+      'click .js-continue': '_onClickContinue',
+      'click .js-cancel': '_onClickCancel'
+    },
+
+    initialize: function (options) {
+      this.options = _.extend({}, App.Component.Tooltip.prototype.defaults, this.defaults, options);
+      this._setVars();
+      this.render();
+
+      // The tooltip needs to be hidden before being shown for the first time
+      this.hideTooltip();
+      this.showTooltip();
+    },
+
+    /**
+     * Event handler executed when the user clicks the continue button
+     */
+    _onClickContinue: function () {
+      this.options.continueCallback.apply(this);
+    },
+
+    /**
+     * Event handler executed when the user clicks the cancel button
+     */
+    _onClickCancel: function () {
+      this.options.cancelCallback.apply(this);
+    },
+
+    /**
+     * Return the content of the tooltip
+     * @override
+     * @return {string}
+     */
+    _getContent: function () {
+      return this.template({
+        direction: '-' + this.options.direction,
+        title: this.options.title,
+        description: this.options.description
+      });
+    },
+
+    render: function () {
+      App.Component.Tooltip.prototype.render.apply(this);
+      // this.setElement(this.el);
+    }
+  });
+}).call(this, this.App);

--- a/app/assets/stylesheets/_settings.scss
+++ b/app/assets/stylesheets/_settings.scss
@@ -4,6 +4,7 @@ $font-family-1: 'Montserrat', sans-serif;
 $font-family-2: 'Chalet';
 
 $font-size-s: 13px;
+$font-size-xxs: 14px;
 $font-size-xs: 16px;
 $font-size-xxm: 24px;
 $font-size-xm: 35px;

--- a/app/assets/stylesheets/components/data-portal/c-widget-warning-tooltip.scss
+++ b/app/assets/stylesheets/components/data-portal/c-widget-warning-tooltip.scss
@@ -1,0 +1,31 @@
+.c-widget-warning-tooltip {
+  @extend .c-chart-tooltip;
+
+  display: block;
+  position: relative;
+  top: -10px;
+  width: 300px;
+  padding: 20px;
+  text-align: left;
+
+  h3 {
+    margin-bottom: 10px;
+    font-family: $font-family-2;
+    font-size: $font-size-xs;
+    line-height: 1.3;
+  }
+
+  p {
+    font-size: $font-size-xxs;
+  }
+
+  .buttons {
+    display: flex;
+    justify-content: space-between;
+    margin-top: 20px;
+
+    button {
+      flex-basis: calc(50% - 10px);
+    }
+  }
+}


### PR DESCRIPTION
This PR implements a warning tooltip which asks the user to confirm certain actions incompatible with the current state of the widget. Those actions are:
- setting the analysis mode when the compare one is active
- setting the compare mode when the analysis one is active
- changing the chart visualisation when the compare mode is active
- changing the chart visualisation when the analysis mode is active

If the user confirms then the previous mode is disabled and the configuration lost. If they cancel, the tooltip closes.

<img width="1097" alt="Screenshot of the tooltip when trying to change the visualisation while the compare mode is active" src="https://cloud.githubusercontent.com/assets/6073968/24403371/77fcf6e8-13b4-11e7-86d7-de1edaf0101f.png">