### PR TITLE
Feature/data portal serialization

### DIFF
--- a/app/assets/javascripts/collections/data_portal/IndicatorsCollection.js
+++ b/app/assets/javascripts/collections/data_portal/IndicatorsCollection.js
@@ -1,0 +1,32 @@
+(function (App) {
+  'use strict';
+
+  var INDICATORS = [
+    { id: 'geographic_area', name: 'Geographic Area', category: 'Common Indicators', visible: false },
+    { id: 'gender', name: 'Gender', category: 'Common Indicators', visible: false },
+    { id: 'age',name: 'Age', category: 'Common Indicators', visible: false },
+    // { id: 'access_to_resources', name: 'Access to Resources', category: 'Common Indicators', visible: false },
+    // { id: 'dwelling_type', name: 'Dwelling type: roof/dwelling', category: 'Common Indicators', visible: false },
+    { id: 'i2i_Marital_Status', name: 'Marital Status', category: 'Common Indicators', visible: false },
+    { id: 'i2i_Education', name: 'Level of education', category: 'Common Indicators', visible: true },
+    { id: 'i2i_Income_Sources', name: 'Sources of income', category: 'Common Indicators', visible: true },
+    { id: 'fas_strand', name: 'Financial services uptake', category: 'Financial Access', visible: true },
+    { id: 'savings_strand', name: 'Savings', category: 'Financial Access', visible: true },
+    { id: 'credit_strand', name: 'Credit', category: 'Financial Access', visible: true },
+    { id: 'remittances_strand', name: 'Send and receive money', category: 'Financial Access', visible: false },
+    { id: 'insurance_strand', name: 'Insurance', category: 'Financial Access', visible: false }
+    // { id: 'total_strands', name: 'Strands', category: 'Financial Access', visible: false }
+  ];
+
+  App.Collection.IndicatorsCollection = Backbone.Collection.extend({
+
+    fetch: function () {
+      var deferred = $.Deferred();
+      this.set(INDICATORS);
+      deferred.resolve(INDICATORS);
+      return deferred;
+    },
+
+  });
+
+}).call(this, this.App);

--- a/app/assets/javascripts/data_portal.js.erb
+++ b/app/assets/javascripts/data_portal.js.erb
@@ -31,6 +31,7 @@
 //= require_tree ./templates/data_portal
 //= require_tree ./components/shared
 //= require_tree ./components/data_portal
+//= require_tree ./collections/data_portal/
 //= require_tree ./models/data_portal/
 //= require_tree ./views/shared/
 //= require_tree ./views/data_portal/

--- a/app/assets/javascripts/helpers/filters.js
+++ b/app/assets/javascripts/helpers/filters.js
@@ -1,0 +1,29 @@
+((function (App) {
+  App.Helper.Filters = {
+    /**
+     * Serialize a filter
+     * @param {{ id: string, name: string, options: string[] }} filter
+     * @return {{ id: string, n: string, o: string[] }}
+     */
+    serialize: function (filter) {
+      return {
+        id: filter.id,
+        n: filter.name,
+        o: filter.options
+      };
+    },
+
+    /**
+     * Deserialize a filter
+     * @param {{ id: string, n: string, o: string[] }} filter
+     * @return {{ id: string, name: string, options: string[] }}
+     */
+    deserialize: function (serializedFilter) {
+      return {
+        id: serializedFilter.id,
+        name: serializedFilter.n,
+        options: serializedFilter.o
+      };
+    }
+  };
+})(this.App));

--- a/app/assets/javascripts/helpers/indicators.js
+++ b/app/assets/javascripts/helpers/indicators.js
@@ -20,12 +20,12 @@
 
     /**
      * Serialize an indicator
-     * @param {{ indicator: string, iso: string, year: number, chart: string, analysisIndicator: {}, compareIndicators: {}[] }} indicator
+     * @param {{ id: string, iso: string, year: number, chart: string, analysisIndicator: {}, compareIndicators: {}[] }} indicator
      * @return {{ id: string, i: string, y: number, c: string, an: {}, cp: {}[] }}
      */
     serialize: function (indicator) {
       return {
-        id: indicator.indicator,
+        id: indicator.id,
         i: indicator.iso,
         y: indicator.year,
         c: indicator.chart,
@@ -37,11 +37,11 @@
     /**
      * Serialize an indicator
      * @param {{ id: string, i: string, y: number, c: string, an: {}, cp: {}[] }} serializedIndicator
-     * @return {{ indicator: string, iso: string, year: number, chart: string, analysisIndicator: {}, compareIndicators: {}[] }}
+     * @return {{ id: string, iso: string, year: number, chart: string, analysisIndicator: {}, compareIndicators: {}[] }}
      */
     deserialize: function (serializedIndicator) {
       return {
-        indicator: serializedIndicator.id,
+        id: serializedIndicator.id,
         iso: serializedIndicator.i,
         year: serializedIndicator.y,
         chart: serializedIndicator.c,

--- a/app/assets/javascripts/helpers/indicators.js
+++ b/app/assets/javascripts/helpers/indicators.js
@@ -35,7 +35,7 @@
     },
 
     /**
-     * Serialize an indicator
+     * Deserialize an indicator
      * @param {{ id: string, i: string, y: number, c: string, an: {}, cp: {}[] }} serializedIndicator
      * @return {{ id: string, iso: string, year: number, chart: string, analysisIndicator: {}, compareIndicators: {}[] }}
      */

--- a/app/assets/javascripts/helpers/indicators.js
+++ b/app/assets/javascripts/helpers/indicators.js
@@ -16,6 +16,38 @@
       KEN: 'Kenya',
       MOZ: 'Mozambique',
       PAK: 'Pakistan'
+    },
+
+    /**
+     * Serialize an indicator
+     * @param {{ indicator: string, iso: string, year: number, chart: string, analysisIndicator: {}, compareIndicators: {}[] }} indicator
+     * @return {{ id: string, i: string, y: number, c: string, an: {}, cp: {}[] }}
+     */
+    serialize: function (indicator) {
+      return {
+        id: indicator.indicator,
+        i: indicator.iso,
+        y: indicator.year,
+        c: indicator.chart,
+        an: indicator.analysisIndicator,
+        cp: compareIndicators
+      };
+    },
+
+    /**
+     * Serialize an indicator
+     * @param {{ id: string, i: string, y: number, c: string, an: {}, cp: {}[] }} serializedIndicator
+     * @return {{ indicator: string, iso: string, year: number, chart: string, analysisIndicator: {}, compareIndicators: {}[] }}
+     */
+    deserialize: function (serializedIndicator) {
+      return {
+        indicator: serializedIndicator.id,
+        iso: serializedIndicator.i,
+        year: serializedIndicator.y,
+        chart: serializedIndicator.c,
+        analysisIndicator: serializedIndicator.an,
+        compareIndicators: serializedIndicator.cp
+      };
     }
   };
 })(this.App));

--- a/app/assets/javascripts/pages/data_portal/DataPortalCountryPage.js
+++ b/app/assets/javascripts/pages/data_portal/DataPortalCountryPage.js
@@ -1,43 +1,6 @@
 (function (App) {
   'use strict';
 
-  var IndicatorsCollection = Backbone.Collection.extend({
-    // initialize: function (iso, year) {
-    //   this.iso = iso;
-    //   this.year = year;
-    // },
-
-    // url: function() {
-    //   return API_URL + '/indicator/' + this.iso + '/' + this.year;
-    // },
-
-    // parse: function (data) {
-    //   return _.uniq(data.data.map(function (o) { return o.indicatorId }))
-    //     .map(function (indicatorId) {
-    //       return {
-    //         indicator: indicatorId
-    //       };
-    //     });
-    // }
-  });
-
-  var INDICATORS = [
-    { id: 'geographic_area', name: 'Geographic Area', category: 'Common Indicators', visible: false },
-    { id: 'gender', name: 'Gender', category: 'Common Indicators', visible: false },
-    { id: 'age',name: 'Age', category: 'Common Indicators', visible: false },
-    // { id: 'access_to_resources', name: 'Access to Resources', category: 'Common Indicators', visible: false },
-    // { id: 'dwelling_type', name: 'Dwelling type: roof/dwelling', category: 'Common Indicators', visible: false },
-    { id: 'i2i_Marital_Status', name: 'Marital Status', category: 'Common Indicators', visible: false },
-    { id: 'i2i_Education', name: 'Level of education', category: 'Common Indicators', visible: true },
-    { id: 'i2i_Income_Sources', name: 'Sources of income', category: 'Common Indicators', visible: true },
-    { id: 'fas_strand', name: 'Financial services uptake', category: 'Financial Access', visible: true },
-    { id: 'savings_strand', name: 'Savings', category: 'Financial Access', visible: true },
-    { id: 'credit_strand', name: 'Credit', category: 'Financial Access', visible: true },
-    { id: 'remittances_strand', name: 'Send and receive money', category: 'Financial Access', visible: false },
-    { id: 'insurance_strand', name: 'Insurance', category: 'Financial Access', visible: false }
-    // { id: 'total_strands', name: 'Strands', category: 'Financial Access', visible: false }
-  ];
-
   var MapUrlModel = Backbone.Model.extend({
 
     initialize: function (iso) {
@@ -85,7 +48,7 @@
 
     initialize: function (settings) {
       this.options = _.extend({}, this.defaults, settings);
-      this.indicatorsCollection = new IndicatorsCollection();
+      this.indicatorsCollection = new App.Collection.IndicatorsCollection();
       this.mapUrlModel = new MapUrlModel(this.options.iso);
       this.headerContainer = this.el.querySelector('.js-header');
       this.widgetsContainer = this.el.querySelector('.js-widgets');
@@ -195,14 +158,7 @@
       this.render();
 
       $.when.apply($, [
-        (function () {
-          var deferred = $.Deferred();
-          this.indicatorsCollection.set(INDICATORS);
-          deferred.resolve(INDICATORS);
-
-          // return this.indicatorsCollection.fetch()
-          return deferred;
-        }.bind(this))(),
+        this.indicatorsCollection.fetch(),
         this.mapUrlModel.fetch()
       ])
         .done(function (){
@@ -374,8 +330,7 @@
       visibleIndicators.forEach(function (indicator, index) {
         var widget = new App.View.ChartWidgetView({
           el: this.widgetsContainer.children[index].children[0],
-          indicators: this.indicatorsCollection.toJSON(),
-          indicator: indicator,
+          id: indicator.id,
           iso: this.options.iso,
           year: this.options.year,
           filters: this.options._filters

--- a/app/assets/javascripts/views/data_portal/ChartWidgetView.js
+++ b/app/assets/javascripts/views/data_portal/ChartWidgetView.js
@@ -15,10 +15,8 @@
       _width: null,
       // Inner height of the chart, used internally
       _height: null,
-      // Indicator information
-      indicator: null,
-      // List of all the indicators
-      indicators: [],
+      // Indicator id
+      id: null,
       // ISO of the country
       iso: null,
       // Selected year
@@ -47,6 +45,7 @@
 
     initialize: function (settings) {
       this.options = _.extend({}, this.defaults, settings);
+      this.indicatorsCollection = new App.Collection.IndicatorsCollection();
       this._fetchData();
     },
 
@@ -55,6 +54,37 @@
      */
     _setListeners: function () {
       window.addEventListener('resize', _.debounce(this._onResize.bind(this), 150));
+    },
+
+    /**
+     * Event handler executed when the data is fetched
+     */
+    _onFetch: function () {
+      var data = this.model.get('data');
+      if (data.length) this.widgetToolbox = new App.Helper.WidgetToolbox(data);
+
+      // If the indicator doesn't have any data, we also want to send an event
+      // to notify the parent view about it
+      this.trigger('data:sync', {
+        id: this.options.id,
+        name: this.model.get('title'),
+        data: data
+      });
+
+      // We pre-render the component with its template
+      this.el.innerHTML = this.template({
+        name: this.model.get('title'),
+        noData: !data.length,
+        showToolbar: this.options.showToolbar,
+        canAnalyze: this._getIndicator().category === App.Helper.Indicators.CATEGORIES.ACCESS,
+        canCompare: this._getIndicator().category === App.Helper.Indicators.CATEGORIES.ACCESS,
+        isAnalyzing: !!this.options.analysisIndicator,
+        isComparing: !!this.options.compareIndicators
+      });
+      this.chartContainer = this.el.querySelector('.js-chart');
+
+      this.render();
+      this._setListeners();
     },
 
     /**
@@ -239,7 +269,7 @@
       var jurisdictionFilter = _.findWhere(this.options.filters, { id: 'jurisdiction' });
 
       new App.Component.ModalChartCompare({
-        indicator: this.options.indicator,
+        indicator: this._getIndicator(),
         iso: this.options.iso,
         year: this.options.year,
         filters: this.options.filters,
@@ -264,7 +294,7 @@
      * Open the modal for the chart analysis
      */
     _openModalChartAnalysis: function () {
-      var nonAccessIndicators = this.options.indicators.filter(function (indicator) {
+      var nonAccessIndicators = this.indicatorsCollection.toJSON().filter(function (indicator) {
         return indicator.category !== App.Helper.Indicators.CATEGORIES.ACCESS;
       });
 
@@ -324,49 +354,50 @@
       // We show the spinning loader
       this._showLoader();
 
-      // We create a new model each time we request the data because the
-      // model options eventually changed
-      this.model = new App.Model.ChartWidgetModel({
-        id: this.options.indicator.id,
-        iso: this.options.iso,
-        year: this.options.year,
-        indicator: this.options.indicator,
-        filters: this.options.filters,
-        analysisIndicatorId: this.options.analysisIndicator,
-        compareIndicators: this.options.compareIndicators,
-        expanded: this.options.chart === 'table'
-      });
+      // We fetch the indicators only once
+      var deferred = $.Deferred();
+      if (!this.indicatorsCollection.length) {
+        this.indicatorsCollection.fetch()
+          .done(deferred.resolve)
+          .fail(deferred.reject);
+      } else {
+        deferred.resolve();
+      }
 
-      this.model.fetch()
-        .done(function () {
-          var data = this.model.get('data');
-          if (data.length) this.widgetToolbox = new App.Helper.WidgetToolbox(data);
-
-          // If the indicator doesn't have any data, we also want to send an event
-          // to notify the parent view about it
-          this.trigger('data:sync', {
-            id: this.options.indicator.id,
-            name: this.model.get('title'),
-            data: data
+      deferred
+        .then(function () {
+          // We create a new model each time we request the data because the
+          // model options eventually changed
+          this.model = new App.Model.ChartWidgetModel({
+            id: this.options.id,
+            iso: this.options.iso,
+            year: this.options.year,
+            indicator: this._getIndicator(),
+            filters: this.options.filters,
+            analysisIndicatorId: this.options.analysisIndicator,
+            compareIndicators: this.options.compareIndicators,
+            expanded: this.options.chart === 'table'
           });
 
-          // We pre-render the component with its template
-          this.el.innerHTML = this.template({
-            name: this.model.get('title'),
-            noData: !data.length,
-            showToolbar: this.options.showToolbar,
-            canAnalyze: this.options.indicator.category === App.Helper.Indicators.CATEGORIES.ACCESS,
-            canCompare: this.options.indicator.category === App.Helper.Indicators.CATEGORIES.ACCESS,
-            isAnalyzing: !!this.options.analysisIndicator,
-            isComparing: !!this.options.compareIndicators
-          });
-          this.chartContainer = this.el.querySelector('.js-chart');
-
-          this.render();
-          this._setListeners();
+          this.model.fetch()
+            .done(this._onFetch.bind(this))
+            .fail(this.renderError.bind(this))
+            .always(this._hideLoader.bind(this));
         }.bind(this))
-        .fail(this.renderError.bind(this))
-        .always(this._hideLoader.bind(this));
+        .fail(function () {
+          this.renderError();
+          this._hideLoader();
+        }.bind(this));
+    },
+
+    /**
+     * Return the detailed information about the indicator
+     * @return {{ id: string, name: string, category: string, visible: boolean }}
+     */
+    _getIndicator: function () {
+      var indicator = this.indicatorsCollection.findWhere({ id: this.options.id });
+      if (indicator) return indicator.toJSON()
+      return null;
     },
 
     /**
@@ -376,7 +407,7 @@
     _getAvailableCharts: function () {
       return this.widgetToolbox.getAvailableCharts().filter(function (chartName) {
         var chart = _.findWhere(App.Helper.ChartConfig, { name: chartName });
-        return !chart.categories || chart.categories.indexOf(this.options.indicator.category) !== -1;
+        return !chart.categories || chart.categories.indexOf(this._getIndicator().category) !== -1;
       }, this);
     },
 
@@ -485,7 +516,7 @@
      */
     _renderChart: function () {
       if (this.options.chart === 'table') {
-        var isAccess = this.options.indicator.category === App.Helper.Indicators.CATEGORIES.ACCESS;
+        var isAccess = this._getIndicator().category === App.Helper.Indicators.CATEGORIES.ACCESS;
 
         new App.View.TableView({
           el: this.chartContainer,


### PR DESCRIPTION
This PR implements the method to serialise the filters and the widgets.

It also changes the required parameters of `ChartWidgetView` by removing `indicator` and `indicators` and adding `id`. This will help reduce the size of the serialised objects.

As a consequence, the list of indicators has been moved to its own view.