### PR TITLE
Bug/data portal share modal a11y

### DIFF
--- a/app/assets/javascripts/components/data_portal/modals/modal-save-widget.js
+++ b/app/assets/javascripts/components/data_portal/modals/modal-save-widget.js
@@ -141,8 +141,10 @@
       modal.style.top = modalDimension.offsets.top + 'px';
       modal.style.left = modalDimension.offsets.left + 'px';
 
+      var modalHeight = Math.min(modalDimension.bounds.height, 550);
+
       modalContent.style.width = modalDimension.bounds.width + 'px';
-      modalContent.style.height = modalDimension.bounds.height + 'px';
+      modalContent.style.height = modalHeight + 'px';
     },
 
     /**

--- a/app/assets/javascripts/components/data_portal/modals/modal-save-widget.js
+++ b/app/assets/javascripts/components/data_portal/modals/modal-save-widget.js
@@ -218,8 +218,9 @@
     },
 
     _renderSlides: function () {
+      var slidesContainer = this.$el.find('.js-slider-container');
       this.slides.forEach(function (slide) {
-        $(this.el.querySelector('.js-slider-container')).append(slide.view.render());
+        slidesContainer.append(slide.view.render());
       }.bind(this));
     },
 

--- a/app/assets/javascripts/components/data_portal/slide.js
+++ b/app/assets/javascripts/components/data_portal/slide.js
@@ -4,30 +4,30 @@
     defaults: {
       // Callback to be executed after an action (show or close)
       callback: function () {},
-      // content to render in the modal
+      // Title of the slide - mandatory
+      title: '',
+      // content to render in the slide
       content: ''
     },
 
     initialize: function (settings) {
       this.options = _.extend({}, this.defaults, settings);
+      this._onTransitionend = this._onTransitionend.bind(this);
+    },
+
+    _onTransitionend: function () {
+      if (this.el.classList.contains('-visible')) {
+        this.previsouslyFocusedEl = document.activeElement;
+        this.el.focus();
+      } else {
+        this.previsouslyFocusedEl.focus();
+        this.el.removeEventListener('transitionend', this._onTransitionend);
+      }
     },
 
     toggleVisibility: function (visible) {
-      // Incoming slide styles
-      if (visible) {
-        this.el.classList.add('-enter');
-
-        if (this.el.classList.contains('-leave')) {
-          this.el.classList.remove('-leave');
-        }
-        return;
-      }
-
-      // Outgoing slide styles
-      if (this.el.classList.contains('-enter')) {
-        this.el.classList.remove('-enter');
-        this.el.classList.add('-leave');
-      }
+      this.el.addEventListener('transitionend', this._onTransitionend);
+      this.el.classList.toggle('-visible', visible);
     },
 
     onCallback: function () {
@@ -36,6 +36,8 @@
 
     render: function () {
       this.el.innerHTML = this.options.content;
+      this.el.setAttribute('aria-label', this.options.title);
+      this.el.setAttribute('tabindex', 0);
     }
   });
 }).call(this, this.App);

--- a/app/assets/javascripts/templates/data_portal/slides/shareWidget.jst.ejs
+++ b/app/assets/javascripts/templates/data_portal/slides/shareWidget.jst.ejs
@@ -2,12 +2,12 @@
   <button class="back js-back" aria-label="Close sharing options">Share</button>
   <ul class="social-links-list">
     <li class="social-links-item -twitter">
-      <a href="<%= twitter %>" alt="share-twitter" target="_blank" ref="noopener noreferrer">
+      <a href="<%= twitter %>" aria-label="Share on Twitter" target="_blank" ref="noopener noreferrer">
         <svg class="icon icon-twitter"><use xlink:href="#icon-twitter"></use></svg>
       </a>
     </li>
     <li class="social-links-item -facebook">
-      <a href="<%= facebook %>" alt="share-facebook" target="_blank" ref="noopener noreferrer">
+      <a href="<%= facebook %>" aria-label="Share on Facebook" target="_blank" ref="noopener noreferrer">
         <svg class="icon icon-facebook"><use xlink:href="#icon-facebook"></use></svg>
       </a>
     </li>
@@ -20,7 +20,7 @@
         <div class="copy-field">
           <%= page_link %>
         </div>
-        <button class="c-button -sea copy-button js-copy">Copy</button>
+        <button class="c-button -sea copy-button js-copy" aria-label="Copy URL">Copy</button>
       </div>
     </li>
     <li class="page-links-item">
@@ -29,7 +29,7 @@
         <div class="copy-field">
           <%= _.escape(embed_link) %>
         </div>
-        <button class="c-button -sea -disabled copy-button js-copy">Copy</button>
+        <button class="c-button -sea -disabled copy-button js-copy" aria-label="Copy embed code">Copy</button>
       </div>
     </li>
   </ul>

--- a/app/assets/javascripts/templates/data_portal/slides/shareWidget.jst.ejs
+++ b/app/assets/javascripts/templates/data_portal/slides/shareWidget.jst.ejs
@@ -1,5 +1,5 @@
 <div class="c-share-widget">
-  <div class="back js-back">Share</div>
+  <button class="back js-back" aria-label="Close sharing options">Share</button>
   <ul class="social-links-list">
     <li class="social-links-item -twitter">
       <a href="<%= twitter %>" alt="share-twitter" target="_blank" ref="noopener noreferrer">

--- a/app/assets/javascripts/views/data_portal/slides/ShareView.js.erb
+++ b/app/assets/javascripts/views/data_portal/slides/ShareView.js.erb
@@ -19,6 +19,14 @@
       'blur  .js-copy': '_onBlur'
     },
 
+    initialize: function (options) {
+      this.defaults = _.extend({}, this.defaults, {
+        title: 'Sharing options'
+      });
+
+      App.Component.Slide.prototype.initialize.call(this, options);
+    },
+
     _onCopy: function (e) {
       var copyButton = e.currentTarget;
 

--- a/app/assets/stylesheets/components/data-portal/c-modal-save-widget.scss
+++ b/app/assets/stylesheets/components/data-portal/c-modal-save-widget.scss
@@ -6,5 +6,7 @@
   > .c-widget {
     height: 100%;
     margin: 0;
+    overflow-y: auto;
+    -webkit-overflow-scrolling: touch;
   }
 }

--- a/app/assets/stylesheets/components/data-portal/c-slider.scss
+++ b/app/assets/stylesheets/components/data-portal/c-slider.scss
@@ -1,31 +1,26 @@
-
 .c-slider {
   position: absolute;
   top: 0;
-  left: 0;
+  left: calc(100% + 1px);
   width: 100%;
   height: 100%;
-  transform: translate(calc(100% + 1px), 0);
 
   > .slide {
-    display: inline-block;
+    display: block;
     position: absolute;
+    top: 0;
+    left: 0;
     width: 100%;
     height: 100%;
     padding: 30px;
-
-    transition: .15s ease-out transform;
+    transition: transform .3s ease-out, visibility 0s .3s;
     background-color: $color-4;
+    visibility: hidden;
 
-    &.-enter {
+    &.-visible {
       transform: translate(calc(-100% - 1px), 0);
-      z-index: 1;
-    }
-
-    &.-leave {
-      transform: translate(0, 0);
-      transition-delay: .15s;
-      z-index: -1;
+      transition: transform .3s ease-out, visibility 0s;
+      visibility: visible;
     }
 
     .back {


### PR DESCRIPTION
This PR fixes accessibility issues regarding the "Save" modal:
- it prevents the user from reaching the sharing options with the tab key without having to click the "Share" button
- it focuses the user on the share slide when opened
- it lets the user close the share slide
- it adds missing labels for the focusable elements

In addition, the PR limits the height of the modal so the button fit the screen. As a consequence, the modal doesn't cover the full widget anymore if it's really tall. In practice, it will only affect the compared indicators or those with a table graph.