### PR TITLE
Let the user remove a widget from a report

### DIFF
--- a/app/assets/javascripts/components/data_portal/modals/modal-save-widget.js
+++ b/app/assets/javascripts/components/data_portal/modals/modal-save-widget.js
@@ -45,76 +45,6 @@
       }];
     },
 
-    //  *** localStorage private methods ***
-
-    /**
-     * Returns an array of indicators or an empty array
-     * @return {object[]} - Array of indicators
-     */
-    _getSavedIndicators: function() {
-      return localStorage.getItem('indicators') ?
-        JSON.parse(localStorage.getItem('indicators')) : [];
-    },
-
-    /**
-     * Serializes indicator's properties
-     * @param {object} indicator - indicator to be serialiazed
-     */
-    _serializeIndicator: function(indicator) {
-      return App.Helper.Indicators.serialize(indicator);
-    },
-
-    /**
-     * Adds the given indicator to localStorage collection
-     * @param {object} indicator - indicator to be added
-     */
-    _saveIndicator: function(indicator) {
-      var savedIndicators = this._getSavedIndicators();
-      var serializedIndicator = this._serializeIndicator(indicator);
-
-      savedIndicators.push(serializedIndicator);
-      localStorage.setItem('indicators', JSON.stringify(savedIndicators));
-
-      Backbone.Events.trigger('indicator:saved');
-    },
-
-    /**
-     * Removes the given indicator from localStorage collection
-     * @param {object} indicatorToRemove - indicator to be removed
-     */
-    _removeIndicator: function(indicatorToRemove) {
-      var serializedIndicator = this._serializeIndicator(indicatorToRemove);
-      var savedIndicators = this._getSavedIndicators();
-      savedIndicators = savedIndicators.filter(function (savedIndicator) {
-        return !_.isEqual(savedIndicator, serializedIndicator);
-      });
-
-      localStorage.setItem('indicators', JSON.stringify(savedIndicators));
-      Backbone.Events.trigger('indicator:saved');
-    },
-
-    /**
-     * Check if the indicator is already saved in the localStorage object.
-     * @param {object} indicator - checked indicator
-     * @return {boolean} isEqual - It's saved or not
-     */
-    _isIndicatorSaved: function (indicator) {
-      var serializedIndicator = this._serializeIndicator(indicator);
-      var savedIndicators = this._getSavedIndicators();
-
-      if (!savedIndicators.length) {
-        return false;
-      }
-
-      var isSaved = savedIndicators.find(function (savedIndicator) {
-        return _.isEqual(serializedIndicator, savedIndicator);
-      });
-
-      return !!isSaved;
-    },
-
-    //  *** END localStorage private methods ***
-
     /**
      * @return {object} - object with bounds and offsets properties of the modal
      */
@@ -177,7 +107,7 @@
      */
     _toggleButtons: function () {
       var currentIndicator = _.extend({}, this.options.widgetConfig);
-      var isSaved = this._isIndicatorSaved(currentIndicator);
+      var isSaved = App.Helper.Indicators.isIndicatorSaved(currentIndicator);
 
       this.el.querySelector('.js-add-report').classList.toggle('_is-hidden', isSaved);
       this.el.querySelector('.js-remove-report').classList.toggle('_is-hidden', !isSaved);
@@ -187,7 +117,7 @@
       var indicator = _.extend({}, this.options.widgetConfig);
 
       // adds indicator to localStorage
-      this._saveIndicator(indicator);
+      App.Helper.Indicators.saveIndicator(indicator);
 
       this._toggleButtons();
     },
@@ -196,7 +126,7 @@
       var indicator = _.extend({}, this.options.widgetConfig);
 
       // removes indicator from localStorage
-      this._removeIndicator(indicator);
+      App.Helper.Indicators.removeIndicator(indicator);
 
       this._toggleButtons();
     },

--- a/app/assets/javascripts/helpers/indicators.js
+++ b/app/assets/javascripts/helpers/indicators.js
@@ -88,6 +88,64 @@
           })
           : null
       };
+    },
+
+    /**
+     * Return the list of saved indicators from the local storage
+     * @return {{ id: string, i: string, y: number, c: string, f: {}[], an: string, cp: {}[] }[]}
+     */
+    getSavedIndicators: function () {
+      var indicators = localStorage.getItem('indicators');
+      try {
+        return indicators ? JSON.parse(indicators) : [];
+      } catch(e) {
+        return [];
+      }
+    },
+
+    /**
+     * Save an indicator in the local storage
+     * @param {{ id: string, iso: string, year: number, chart: string, filters: {}[], analysisIndicator: string, compareIndicators: {}[] }} indicator
+     */
+    saveIndicator: function (indicator) {
+      var savedIndicators = this.getSavedIndicators();
+      var serializedIndicator = App.Helper.Indicators.serialize(indicator);
+
+      savedIndicators.push(serializedIndicator);
+      localStorage.setItem('indicators', JSON.stringify(savedIndicators));
+
+      Backbone.Events.trigger('indicator:saved');
+    },
+
+    /**
+     * Remove an indicator from the local storage
+     * @param {{ id: string, iso: string, year: number, chart: string, filters: {}[], analysisIndicator: string, compareIndicators: {}[] }} indicator
+     */
+    removeIndicator: function (indicator) {
+      var savedIndicators = this.getSavedIndicators();
+      var serializedIndicator = App.Helper.Indicators.serialize(indicator);
+
+      savedIndicators = savedIndicators.filter(function (ind) {
+        return !_.isEqual(ind, serializedIndicator);
+      });
+      localStorage.setItem('indicators', JSON.stringify(savedIndicators));
+
+      Backbone.Events.trigger('indicator:saved');
+    },
+
+    /**
+     * Return whether an indicator has been saved in the local storage
+     * @param {{ id: string, iso: string, year: number, chart: string, filters: {}[], analysisIndicator: string, compareIndicators: {}[] }} indicator
+     */
+    isIndicatorSaved: function (indicator) {
+      var savedIndicators = this.getSavedIndicators();
+      var serializedIndicator = App.Helper.Indicators.serialize(indicator);
+
+      if (!savedIndicators.length) return false;
+
+      return !!savedIndicators.find(function (ind) {
+        return _.isEqual(ind, serializedIndicator);
+      });
     }
   };
 })(this.App));

--- a/app/assets/javascripts/routers/data_portal.js
+++ b/app/assets/javascripts/routers/data_portal.js
@@ -66,7 +66,7 @@
 
       // redirect to data-portal if there is no indicators to display
       if (!indicators.length) {
-        Turbolinks.visit("/data-portal", { action: "replace" });
+        Turbolinks.visit('/data-portal', { action: 'replace' });
         return;
       }
 

--- a/app/assets/javascripts/templates/data_portal/chart-widget.jst.ejs
+++ b/app/assets/javascripts/templates/data_portal/chart-widget.jst.ejs
@@ -4,10 +4,14 @@
 
   <% if (showToolbar) { %>
     <div class="toolbar">
-      <button type="button" class="c-button -mini js-save">Save</button>
-      <button type="button" class="c-button -mini js-change">Change</button>
-      <% if (canCompare) { %><button type="button" class="c-button -mini js-compare" aria-pressed="<%= isComparing %>">Compare</button><% } %>
-      <% if (canAnalyze) { %><button type="button" class="c-button -mini js-analyze" aria-pressed="<%= isAnalyzing %>">Analyse</button><% } %>
+      <% if (report) { %>
+        <button type="button" class="c-button -mini js-delete">Delete</button>
+      <% } else { %>
+        <button type="button" class="c-button -mini js-save">Save</button>
+        <button type="button" class="c-button -mini js-change">Change</button>
+        <% if (canCompare) { %><button type="button" class="c-button -mini js-compare" aria-pressed="<%= isComparing %>">Compare</button><% } %>
+        <% if (canAnalyze) { %><button type="button" class="c-button -mini js-analyze" aria-pressed="<%= isAnalyzing %>">Analyse</button><% } %>
+      <% } %>
     </div>
   <% } %>
 </div>

--- a/app/assets/javascripts/views/data_portal/ChartWidgetView.js
+++ b/app/assets/javascripts/views/data_portal/ChartWidgetView.js
@@ -33,14 +33,19 @@
       // the filters used for the comparation
       compareIndicators: null,
       // Displays widget toolbar
-      showToolbar: true
+      showToolbar: true,
+      // Whether the widget is rendered in a report
+      report: false,
+      // Callback executed when the delete button is clicked
+      onDelete: function () {}
     },
 
     events: {
       'click .js-save': '_onSave',
       'click .js-change': '_onChange',
       'click .js-compare': '_onCompare',
-      'click .js-analyze': '_onAnalyze'
+      'click .js-analyze': '_onAnalyze',
+      'click .js-delete': '_onDelete'
     },
 
     initialize: function (settings) {
@@ -78,6 +83,7 @@
         name: this.model.get('title'),
         noData: !data.length,
         showToolbar: this.options.showToolbar,
+        report: this.options.report,
         canAnalyze: indicatorCategory === App.Helper.Indicators.CATEGORIES.ACCESS
           || indicatorCategory === App.Helper.Indicators.CATEGORIES.STRANDS,
         canCompare: indicatorCategory === App.Helper.Indicators.CATEGORIES.ACCESS
@@ -264,6 +270,13 @@
       if (!this.tooltip) return;
       this.tooltip.remove();
       this.tooltip = null;
+    },
+
+    /**
+     * Event handler executed when the delete button is clicked
+     */
+    _onDelete: function () {
+      this.options.onDelete();
     },
 
     /**


### PR DESCRIPTION
This PR adds a delete button to the widgets of a report. When clicked, the button removes the widget from the report, updates the URL and eventually the local storage.

If the user removes the last widget, they are redirected to the portal's homepage.