### PR TITLE
Implement the table mode

### DIFF
--- a/app/assets/javascripts/pages/data_portal/DataPortalCountryPage.js
+++ b/app/assets/javascripts/pages/data_portal/DataPortalCountryPage.js
@@ -48,7 +48,9 @@
       //   { id: 'my-indicator', name: 'My indicator', options: ['Option 1', 'Option 2'] }
       // ]
       // NOTE: Do not set this property at instantiation time
-      _filters: []
+      _filters: [],
+      // Mode of the portal: "graphics" or "table"
+      _mode: 'graphics'
     },
 
     events: {
@@ -64,6 +66,7 @@
       this.headerContainer = this.el.querySelector('.js-header');
       this.widgetsContainer = this.el.querySelector('.js-widgets');
       this.footerContainer = this.el.querySelector('.js-footer');
+      this.tabsContainers = this.el.querySelectorAll('.js-tabs');
       this._fetchData();
 
       new App.View.ReportFixedBar();
@@ -93,6 +96,59 @@
       this._updateJurisdiction(jurisdiction);
 
       this.render();
+    },
+
+    /**
+     * Event handler executed when the tab is changed
+     * @param {'graphics'|'table'} tabName
+     */
+    _onTabChange: function (tabName) {
+      this.options._mode = tabName;
+
+      if (tabName === 'graphics') {
+        // We need to restore the configuration of the widgets
+        this.widgets.forEach(function (widget) {
+          var widgetConfig = this.widgetsConfig.find(function (widgetConfig) {
+            return widgetConfig.id === widget.options.id;
+          });
+
+          if (!widgetConfig) {
+            // This case can be triggered if the user adds an indicator while in the
+            // table mode
+            widget.options = Object.assign({}, widget.options, {
+              chart: null,
+              showToolbar: true
+            });
+          } else {
+            widget.options = Object.assign({}, widget.options, {
+              chart: widgetConfig.chart,
+              analysisIndicator: widgetConfig.analysisIndicator,
+              compareIndicators: widgetConfig.compareIndicators,
+              showToolbar: true
+            });
+          }
+
+          widget.reload();
+        }, this);
+
+        delete this.widgetsConfig;
+      } else {
+        // We need to save the current configuration of the widgets
+        this.widgetsConfig = this.widgets.map(function (widget) {
+          return Object.assign({}, widget.options);
+        });
+
+        // We update all the widgets to the table view
+        this.widgets.forEach(function (widget) {
+          widget.options = Object.assign({}, widget.options, {
+            chart: 'table',
+            showToolbar: false,
+            analysisIndicator: null,
+            compareIndicators: null
+          });
+          widget.reload();
+        });
+      }
     },
 
     /**
@@ -269,6 +325,20 @@
         country: App.Helper.Indicators.COUNTRIES[this.options.iso],
         population: this._getReadablePopulation()
       });
+
+      // We instantiate the tab views
+      if (!this.tabs) {
+        this.tabs = [];
+        this.tabs = Array.prototype.slice.call(this.tabsContainers)
+          .map(function (container) {
+            return new App.View.SwitcherView({
+              el: container,
+              tabpanel: this.widgetsContainer,
+              currentTab: 'graphics',
+              onChange: this._onTabChange.bind(this)
+            });
+          }, this);
+      }
     },
 
     /**
@@ -362,13 +432,21 @@
 
       // We instantiate the widget views
       visibleIndicators.forEach(function (indicator, index) {
-        var widget = new App.View.ChartWidgetView({
+        var chartOptions = {
           el: this.widgetsContainer.children[index].children[0],
           id: indicator.id,
           iso: this.options.iso,
           year: this.options.year,
           filters: this.options._filters
-        });
+        };
+
+        // If the portal is in table mode, we force the widgets to display
+        // as tables
+        if (this.options._mode === 'table') {
+          chartOptions.chart = 'table';
+        }
+
+        var widget = new App.View.ChartWidgetView(chartOptions);
 
         this.widgets.push(widget);
 

--- a/app/assets/javascripts/views/data_portal/ChartWidgetView.js
+++ b/app/assets/javascripts/views/data_portal/ChartWidgetView.js
@@ -294,6 +294,13 @@
     },
 
     /**
+     * Reload the widget its current configuration
+     */
+    reload: function () {
+      this._fetchData();
+    },
+
+    /**
      * Return the name of the jurisdiction if there's one, null otherwise
      * @return {string|null}
      */

--- a/app/assets/javascripts/views/data_portal/SwitcherView.js
+++ b/app/assets/javascripts/views/data_portal/SwitcherView.js
@@ -1,0 +1,122 @@
+(function (App) {
+  'use strict';
+
+  App.View.SwitcherView = Backbone.View.extend({
+
+    defaults: {
+      // Element containing the content of the tabs
+      // This element is the one with the role "tabpanel"
+      tabpanel: null,
+      // Name of the current tab (name attribute of the tab)
+      // Must be set to the defaut value
+      currentTab: null,
+      // Callback to execute when the active tab is changed
+      // Gets passed the name of the tab
+      onChange: function () {}
+    },
+
+    events: {
+      'click *[role="tab"]': '_onClickTab',
+      'keydown *[role="tab"]': '_onKeyDownTab'
+    },
+
+    initialize: function (options) {
+      this.options = Object.assign({}, this.defaults, options);
+    },
+
+    /**
+     * Event handler executed when the user clicks one of the tab
+     * @param {Event} e
+     */
+    _onClickTab: function (e) {
+      var tab = e.target;
+      var tabName = tab.name;
+
+      if (tabName !== this.options.currentTab) {
+        this._setTab(tabName);
+      }
+    },
+
+    /**
+     * Event handler executed when the user presses a key while focusing
+     * on a tab
+     * @param {Event} e
+     */
+    _onKeyDownTab: function (e) {
+      if (e.keyCode !== 37 && e.keyCode !== 39) return;
+
+      e.preventDefault();
+
+      // We get the list of tabs
+      var tabs = this.el.querySelectorAll('[role="tab"]');
+      tabs = Array.prototype.slice.call(tabs);
+
+      // We get the active tab
+      var activeTab = this._getActiveTab();
+
+      // We get the position of the tab in the list of tabs
+      var activeTabIndex = tabs.indexOf(activeTab);
+
+      // If the user pressed the left arrow
+      if (e.keyCode === 37) {
+        if (activeTabIndex !== 0) {
+          var previousTab = tabs[activeTabIndex - 1];
+          this._setTab(previousTab.name);
+        }
+      } else {
+        if (activeTabIndex !== tabs.length - 1) {
+          var nextTab = tabs[activeTabIndex + 1];
+          this._setTab(nextTab.name);
+        }
+      }
+    },
+
+    /**
+     * Get the active tab element
+     * @return {HTMLElement}
+     */
+    _getActiveTab: function () {
+      var selector = '[role="tab"][name="' + this.options.currentTab + '"]';
+      return this.el.querySelector(selector);
+    },
+
+    /**
+     * Get the list of non-active tabs
+     * @return {HTMLElement[]}
+     */
+    _getNonActiveTabs: function () {
+      var activeTab = this._getActiveTab();
+      return Array.prototype.slice.call(this.el.querySelectorAll('[role="tab"]'))
+        .filter(function (tab) {
+          return tab !== activeTab;
+        });
+    },
+
+    /**
+     * Set the active tab
+     * @param {string} tabName
+     */
+    _setTab: function (tabName) {
+      this.options.currentTab = tabName;
+      this.options.onChange(tabName);
+
+      var activeTab = this._getActiveTab();
+      var nonActiveTabs = this._getNonActiveTabs();
+
+      activeTab.classList.toggle('-current', true);
+      activeTab.setAttribute('tabindex', 0);
+      activeTab.setAttribute('aria-selected', true);
+      activeTab.focus();
+
+      nonActiveTabs.forEach(function (tab) {
+        tab.classList.toggle('-current', false);
+        tab.setAttribute('tabindex', -1);
+        tab.setAttribute('aria-selected', false);
+      });
+
+      this.options.tabpanel.setAttribute('aria-labelledby', tabName + '-tab');
+    }
+
+  });
+
+}).call(this, this.App);

--- a/app/assets/stylesheets/components/shared/c-switcher.scss
+++ b/app/assets/stylesheets/components/shared/c-switcher.scss
@@ -1,4 +1,3 @@
-
 .c-switcher {
   display: flex;
   position: relative;
@@ -16,6 +15,7 @@
     justify-content: center;
     // width: calc(50% - 15px);
     height: calc(100% - 4px);
+    margin: 0;
     padding: 1px 15px 0;
     border-radius: 100px;
 

--- a/app/views/data_portal/show.html.erb
+++ b/app/views/data_portal/show.html.erb
@@ -26,9 +26,9 @@
     <div class="row">
       <div class="l-switcher _no-desktop">
         <div class="grid-s-8 grid-m-4 grid-l-3">
-          <div class="c-switcher">
-            <span class="switcher-option -current">Graphics</span>
-            <span class="switcher-option">Table</span>
+          <div class="c-switcher js-tabs" role="tablist">
+            <button id="graphics-tab" class="switcher-option -current" role="tab" aria-controls="widgets-list" aria-selected="true"Graphics</button>
+            <button id="table-tab" class="switcher-option" role="tab" aria-controls="widgets-list" aria-selected="false" tabindex="-1">Table</button>
           </div>
         </div>
       </div>
@@ -43,9 +43,9 @@
             <div class="row">
               <div class="container">
                 <div class="grid-l-3">
-                  <div class="c-switcher">
-                    <span class="switcher-option -current">Graphics</span>
-                    <span class="switcher-option">Table</span>
+                  <div class="c-switcher js-tabs" role="tablist">
+                    <button id="graphics-tab" class="switcher-option -current" name="graphics" role="tab" aria-controls="widgets-list" aria-selected="true">Graphics</button>
+                    <button id="table-tab" class="switcher-option" name="table" role="tab" aria-controls="widgets-list" aria-selected="false" tabindex="-1">Table</button>
                   </div>
                 </div>
               </div>
@@ -58,7 +58,7 @@
       <div class="wrapper">
         <div class="row">
           <div class="grid-s-12">
-            <div class="row widgets-list js-widgets"></div>
+            <div id="widgets-list" class="row widgets-list js-widgets" role="tabpanel" aria-labelledby="graphics-tab"></div>
           </div>
         </div>
         <div class="row">


### PR DESCRIPTION
This PR implements the table mode where all the indicators display as tables. While in this mode, the user can still use the filters and add new indicators.

<img width="1104" alt="Screenshot of the portal in table mode" src="https://cloud.githubusercontent.com/assets/6073968/25481369/c152b236-2b44-11e7-942b-4cfef7bee031.png">

