### PR TITLE
Feature/responsive charts

### DIFF
--- a/app/assets/javascripts/helpers/chartConfig.js
+++ b/app/assets/javascripts/helpers/chartConfig.js
@@ -19,7 +19,15 @@
   // all the categories
   // - ratio: ratio between the width and the height, if not set, use the
   // default one in App.View.ChartWidgetView
+  // the ratio might not be respected if the template has an hard-coded height
   // - visible: hide the chart from the chart selector; default to true
+  // - responsive:
+  //     * mode: "adaptative" or "scroll"
+  //         > adaptative: a different template is loaded
+  //         > scroll: the widget is rendered as on desktop and the user has to scroll
+  //           horizontally
+  //     * breakpoint: below which size the responsive mode is activated
+  //   If the value is not set, the desktop widget is rendered, without scroll
   App.Helper.ChartConfig = [
     {
       name: 'pie',
@@ -28,7 +36,11 @@
         ['ordinal'],
         ['quantitative']
       ],
-      categories: [App.Helper.Indicators.CATEGORIES.COMMON]
+      categories: [App.Helper.Indicators.CATEGORIES.COMMON],
+      responsive: {
+        mode: 'adaptative',
+        breakpoint: 430
+      }
     },
     {
       name: 'bar',
@@ -37,7 +49,11 @@
         ['ordinal'],
         ['quantitative']
       ],
-      categories: [App.Helper.Indicators.CATEGORIES.COMMON]
+      categories: [App.Helper.Indicators.CATEGORIES.COMMON],
+      responsive: {
+        mode: 'adaptative',
+        breakpoint: 430
+      }
     },
     {
       name: 'stacked bar',
@@ -47,7 +63,11 @@
         ['quantitative']
       ],
       categories: [App.Helper.Indicators.CATEGORIES.STRANDS],
-      ratio: 0.2
+      ratio: 0.2,
+      responsive: {
+        mode: 'adaptative',
+        breakpoint: 430
+      }
     },
     {
       name: 'radial',
@@ -57,18 +77,30 @@
         ['quantitative']
       ],
       categories: [App.Helper.Indicators.CATEGORIES.ACCESS, App.Helper.Indicators.CATEGORIES.STRANDS],
-      ratio: 0.3
+      ratio: 0.3,
+      responsive: {
+        mode: 'scroll',
+        breakpoint: 950
+      }
     },
     {
       name: 'analysis',
       categories: [App.Helper.Indicators.CATEGORIES.ACCESS, App.Helper.Indicators.CATEGORIES.STRANDS],
-      visible: false
+      visible: false,
+      responsive: {
+        mode: 'adaptative',
+        breakpoint: 430
+      }
     },
     {
       name: 'compare',
       categories: [App.Helper.Indicators.CATEGORIES.ACCESS, App.Helper.Indicators.CATEGORIES.STRANDS],
       visible: false,
-      ratio: 0.3
+      ratio: 0.3,
+      responsive: {
+        mode: 'scroll',
+        breakpoint: 950
+      }
     },
     {
       name: 'table',

--- a/app/assets/javascripts/pages/data_portal/DataPortalIndicatorPage.js
+++ b/app/assets/javascripts/pages/data_portal/DataPortalIndicatorPage.js
@@ -75,7 +75,7 @@
       var options = _.extend({}, {
         el: this.widgetContainer,
         showToolbar: false,
-        autoResize: false,
+        autoResize: !this.options.print,
         showDetails: true
       }, this.options._state);
 

--- a/app/assets/javascripts/templates/data_portal/chart-tooltip.jst.ejs
+++ b/app/assets/javascripts/templates/data_portal/chart-tooltip.jst.ejs
@@ -3,3 +3,4 @@
   <h2><%= subtitle %></h2>
 <% } %>
 <div class="value"><%= value %></div>
+<div class="tip js-tip"></div>

--- a/app/assets/javascripts/templates/data_portal/widgets/analysis-mobile.jst.ejs
+++ b/app/assets/javascripts/templates/data_portal/widgets/analysis-mobile.jst.ejs
@@ -1,0 +1,310 @@
+{
+  "width": <%= width %>,
+  "height": 0,
+  "padding": "strict",
+  "data": [
+    {
+      "name": "table",
+      "values": <%= data %>,
+      "transform": [{"type": "filter","test": "datum.label.length"}]
+    },
+    {
+      "name": "scaleValues",
+      "source": "table",
+      "transform": [
+        {
+          "type": "aggregate",
+          "summarize": [{"field": "percentage", "ops": ["max"]}]
+        },
+        {
+          "type": "formula",
+          "field": "max",
+          "expr": "min(datum.max_percentage + 20, 100)"
+        }
+      ]
+    },
+    {
+      "name": "groupValues",
+      "source": "table",
+      "transform": [
+        {
+          "type": "aggregate",
+          "groupby": ["label"],
+          "summarize": [{"field": "percentage","ops": ["values"]}]
+        }
+      ]
+    },
+    {
+      "name": "valuesCount",
+      "source": "groupValues",
+      "transform": [
+        {
+          "type": "aggregate",
+          "summarize": [{"field": "label","ops": ["count"]}]
+        }
+      ]
+    },
+    {
+      "name": "groupsNames",
+      "source": "table",
+      "transform": [
+        {
+          "type": "aggregate",
+          "groupby": ["group"],
+          "summarize": [{"field": "group","ops": ["values"]}]
+        },
+        {
+          "type": "cross",
+          "with": "valuesCount"
+        },
+        {"type": "rank"},
+        {
+          "type": "formula",
+          "field": "pos",
+          "expr": "(datum.rank - 1) * (40 + 14 * datum.b.count_label)"
+        }
+      ]
+    },
+    {
+      "name": "stats",
+      "source": "table",
+      "transform": [
+        {
+          "type": "aggregate",
+          "groupby": ["group"],
+          "summarize": [{"field": "percentage","ops": ["sum"]}]
+        }
+      ]
+    },
+    {
+      "name": "groupsCount",
+      "source": "stats",
+      "transform": [
+        {
+          "type": "aggregate",
+          "summarize": [{"field": "group","ops": ["count"]}]
+        }
+      ]
+    },
+    {
+      "name": "legend",
+      "source": "groupValues",
+      "transform": [
+        {"type": "cross","with": "groupsCount"},
+        {"type": "cross", "with": "valuesCount"},
+        {"type": "rank"},
+        {
+          "type": "formula",
+          "field": "yPos",
+          "expr": "datum.a.b.count_group * (40 + 14 * datum.b.count_label) + datum.rank * 30"
+        },
+        {
+          "type": "formula",
+          "field": "xPos",
+          "expr": "0"
+        }
+      ]
+    },
+    {
+      "name": "rules",
+      "values": [
+        { "x": 10 },
+        { "x": 20 },
+        { "x": 30 },
+        { "x": 40 },
+        { "x": 50 },
+        { "x": 60 },
+        { "x": 70 },
+        { "x": 80 },
+        { "x": 90 }
+      ],
+      "transform": [
+        {"type": "cross", "with": "scaleValues"},
+        {
+          "type": "filter",
+          "test": "datum.a.x < datum.b.max"
+        },
+        {"type": "cross", "with": "groupsCount"},
+        {"type": "cross", "with": "valuesCount"},
+        {
+          "type": "formula",
+          "field": "xPos",
+          "expr": "datum.a.a.a.x"
+        },
+        {
+          "type": "formula",
+          "field": "yPos",
+          "expr": "datum.a.b.count_group * (40 + 14 * datum.b.count_label) - 10"
+        }
+      ]
+    },
+    {
+      "name": "grouped",
+      "source": "table",
+      "transform": [
+        {
+          "type": "facet",
+          "groupby": "group",
+          "transform": [
+            {
+              "type": "cross",
+              "with": "valuesCount"
+            },
+            {"type": "rank"},
+            {
+              "type": "formula",
+              "field": "pos",
+              "expr": "(datum.rank - 1) * 14"
+            },
+            {
+              "type": "formula",
+              "field": "tooltipTitle",
+              "expr": "datum.a.label"
+            },
+            {
+              "type": "formula",
+              "field": "tooltipValue",
+              "expr": "format('.2f', datum.a.percentage) + '%'"
+            }
+          ]
+        },
+        {"type": "rank"},
+        {
+          "type": "formula",
+          "field": "pos",
+          "expr": "(datum.rank - 1) * (40 + 14 * datum.values[0].b.count_label)"
+        }
+      ]
+    }
+  ],
+  "scales": [
+    {
+      "name": "color",
+      "type": "ordinal",
+      "domain": {"data": "groupValues","field": "label"},
+      "range": [
+        "#2f939c",
+        "#97c9ce",
+        "#001d22",
+        "#f9d031",
+        "#f95e31",
+        "#FCAE98",
+        "#633AE8",
+        "#E4D081",
+        "#00D9C6",
+        "#B9A86C",
+        "#7B0051",
+        "#B685C9",
+        "#076270",
+        "#8ADF70"
+      ]
+    },
+    {
+      "name": "outerGroup",
+      "type": "linear",
+      "range": "width",
+      "domainMin": 0,
+      "domainMax": {"data": "scaleValues", "field": "max"}
+    }
+  ],
+  "marks": [
+    {
+      "type": "rule",
+      "from": {"data": "rules"},
+      "properties": {
+        "enter": {
+          "x": {"field": "xPos", "scale": "outerGroup"},
+          "y": {"value": 0, "offset": -10},
+          "y2": {"field": "yPos"},
+          "stroke": {"value": "#ccd2d3"}
+        }
+      }
+    },
+    {
+      "type": "text",
+      "from": {"data": "rules"},
+      "properties": {
+        "enter": {
+          "x": {"field": "xPos", "scale": "outerGroup", "offset": -5},
+          "y": {"field": "yPos"},
+          "text": {"field": "xPos"},
+          "align": {"value": "right"},
+          "baseline": {"value": "bottom"},
+          "font": {"value": "Montserrat"},
+          "fontWeight": {"value": "300"},
+          "fontSize": {"value": 13},
+          "fill": {"value": "#001d22"}
+        }
+      }
+    },
+    {
+      "type": "group",
+      "from": {"data": "grouped"},
+      "properties": {
+        "enter": {
+          "x": {"value": 0},
+          "y": {"field": "pos"},
+          "width": {"field": {"group": "width"}},
+          "height": {"field": {"group": "height"}}
+        }
+      },
+      "marks": [
+        {
+          "name": "hasTooltip",
+          "type": "rect",
+          "properties": {
+            "enter": {
+              "x": {"value": 0},
+              "x2": {"scale": "outerGroup", "field": "a.percentage"},
+              "y": {"field": "pos", "offset": 7},
+              "height": {"value": 10},
+              "fill": {"scale": "color","field": "a.label"}
+            }
+          }
+        }
+      ]
+    },
+    {
+      "type": "text",
+      "from": {"data": "groupsNames"},
+      "properties": {
+        "enter": {
+          "x": {"value": 0},
+          "y": {"field": "pos"},
+          "text": {"field": "a.group"},
+          "font": {"value": "Montserrat"},
+          "fontWeight": {"value": "300"},
+          "fontSize": {"value": 13},
+          "fill": {"value": "#001d22"}
+        }
+      }
+    },
+    {
+      "type": "symbol",
+      "from": {"data": "legend"},
+      "properties": {
+        "enter": {
+          "x": {"field": "xPos","offset": 6},
+          "y": {"field": "yPos"},
+          "size": {"value": 100},
+          "fill": {"scale": "color","field": "a.a.label"}
+        }
+      }
+    },
+    {
+      "type": "text",
+      "from": {"data": "legend"},
+      "properties": {
+        "enter": {
+          "x": {"field": "xPos","offset": 20},
+          "y": {"field": "yPos","offset": 5},
+          "text": {"field": "a.a.label"},
+          "font": {"value": "Montserrat"},
+          "fontWeight": {"value": "300"},
+          "fontSize": {"value": 13},
+          "fill": {"value": "#001d22"}
+        }
+      }
+    }
+  ]
+}

--- a/app/assets/javascripts/templates/data_portal/widgets/bar-mobile.jst.ejs
+++ b/app/assets/javascripts/templates/data_portal/widgets/bar-mobile.jst.ejs
@@ -1,6 +1,6 @@
 {
   "width": <%= width %>,
-  "height": <%= height %>,
+  "height": 0,
   "padding": "strict",
   "data": [
     {
@@ -26,7 +26,7 @@
         {
           "type": "formula",
           "field": "tickLimit",
-          "expr": "datum.b.count_label < 6 ? 30 : (datum.b.count_label < 8 ? 13 : 12)"
+          "expr": "20"
         },
         {
           "type": "formula",
@@ -60,7 +60,7 @@
     {
       "name": "y",
       "type": "linear",
-      "range": "height",
+      "range": [120, 0],
       "domain": [0, 100]
     },
     {
@@ -152,21 +152,44 @@
       }
     },
     {
-      "type": "text",
-      "from": {"data": "table"},
+      "type": "group",
       "properties": {
         "enter": {
-          "x": {"scale": "x", "field": "a.label"},
-          "y": {"scale": "y", "value": 0},
-          "text": {"template": "{{datum.tickLabel}}"},
-          "dy": {"field": "tickPos"},
-          "font": {"value": "Montserrat"},
-          "fontWeight": {"value": "700"},
-          "fontSize": {"value": 11},
-          "fill": {"value": "#001d22"},
-          "align": {"value": "center"}
+          "x": {"value": 0},
+          "y": {"scale": "y", "value": 0}
         }
-      }
+      },
+      "marks": [
+        {
+          "type": "rect",
+          "from": { "data": "table" },
+          "properties": {
+            "enter": {
+              "x": { "value": 0 },
+              "y": {"field": "rank", "mult": 24},
+              "width": { "value": 12 },
+              "height": { "value": 12 },
+              "fill": { "field": "rank", "scale": "color" }
+            }
+          }
+        },
+        {
+          "type": "text",
+          "from": { "data": "table" },
+          "properties": {
+            "enter": {
+              "x": { "value": 20 },
+              "y": {"field": "rank", "mult": 24, "offset": 0},
+              "dy": { "value": 12 },
+              "fontSize": {"value": 13},
+              "fontWeight": {"value": 300},
+              "font": {"value": "inherit"},
+              "fill": { "value": "#001d22" },
+              "text": { "field": "tickLabel" }
+            }
+          }
+        }
+      ]
     }
   ]
 }

--- a/app/assets/javascripts/templates/data_portal/widgets/pie-mobile.jst.ejs
+++ b/app/assets/javascripts/templates/data_portal/widgets/pie-mobile.jst.ejs
@@ -1,0 +1,96 @@
+{
+  "width": <%= width %>,
+  "height": 0,
+  "padding": "strict",
+  "data": [
+    {
+      "name": "table",
+      "values": <%= data %>,
+      "transform": [
+        {"type": "sort","by": "-percentage"},
+        {"type": "pie", "field": "percentage"},
+        {"type": "rank", "field": "-column"},
+        {"type": "formula", "field": "tooltipTitle", "expr": "datum.label"},
+        {"type": "formula", "field": "tooltipValue", "expr": "format('.2f', datum.percentage) + '%'"},
+        {"type": "formula", "field": "label", "expr": "slice(datum.label, 0, 22) + (datum.label.length > 21 ? '...' : '')"}
+      ]
+    }
+  ],
+  "scales": [
+    {
+      "name": "color",
+      "type": "ordinal",
+      "domain": {
+        "data": "table",
+        "field": "label",
+        "sort": {
+          "field": "rank",
+          "op": "mean"
+        }
+      },
+      "range": ["#2f939c","#97c9ce","#001d22","#f9d031","#f95e31", "#FCAE98", "#633AE8", "#E4D081", "#00D9C6", "#B9A86C", "#7B0051", "#B685C9", "#076270", "#8ADF70"]
+    }
+  ],
+  "marks": [
+    {
+      "type": "group",
+      "properties": {
+        "enter": {
+          "x": {"value": 0},
+          "y": {"value": <%= (isNaN(width) ? width : Math.min(250, width)) - 60 %>}
+        }
+      },
+      "marks": [
+        {
+          "type": "rect",
+          "from": { "data": "table" },
+          "properties": {
+            "enter": {
+              "x": { "value": 0 },
+              "y": {"field": "rank","mult": 24},
+              "width": { "value": 12 },
+              "height": { "value": 12 },
+              "fill": { "field": "label", "scale": "color" }
+            }
+          }
+        },
+        {
+          "type": "text",
+          "from": { "data": "table" },
+          "properties": {
+            "enter": {
+              "x": { "value": 20 },
+              "y": {"field": "rank", "mult": 24, "offset": 0},
+              "dy": { "value": 12 },
+              "fontSize": {"value": 13},
+              "fontWeight": {"value": 300},
+              "font": {"value": "inherit"},
+              "fill": { "value": "#001d22" },
+              "text": { "field": "label" }
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "hasTooltip",
+      "type": "arc",
+      "from": {
+        "data": "table"
+      },
+      "properties": {
+        "enter": {
+          "x": { "value": <%= width / 2 %> },
+          "y": { "value": <%= (isNaN(width) ? width : Math.min(250, width)) / 2 - 30 %> },
+          "startAngle": { "field": "layout_start" },
+          "endAngle": { "field": "layout_end" },
+          "innerRadius": { "value": <%= (isNaN(width) ? width : Math.min(250, width)) / 2 - 65 %> },
+          "outerRadius": { "value": <%= (isNaN(width) ? width : Math.min(250, width)) / 2 - 30 %> },
+          "stroke": { "value": "#fff" },
+          "strokeWidth": {"value": 2},
+          "fill": { "field": "label", "scale": "color" }
+        }
+      }
+    }
+  ]
+}

--- a/app/assets/javascripts/templates/data_portal/widgets/stacked-bar-mobile.jst.ejs
+++ b/app/assets/javascripts/templates/data_portal/widgets/stacked-bar-mobile.jst.ejs
@@ -1,0 +1,192 @@
+{
+  "width": <%= width %>,
+  "height": 0,
+  "padding": "strict",
+  "data": [
+    {
+      "name": "table",
+      "values": <%= data %>,
+      "transform": [
+        {"type": "filter","test": "datum.label.length"},
+        {
+          "type": "formula",
+          "field": "tooltipTitle",
+          "expr": "datum.label"
+        },
+        {
+          "type": "formula",
+          "field": "tooltipValue",
+          "expr": "format('.2f', datum.percentage) + '%'"
+        }
+      ]
+    },
+    {
+      "name": "valuesCount",
+      "source": "table",
+      "transform": [
+        {
+          "type": "aggregate",
+          "summarize": [{ "field": "label", "ops": ["count"] }]
+        }
+      ]
+    },
+    {
+      "name": "legend",
+      "source": "table",
+      "transform": [
+        {
+          "type": "cross",
+          "with": "valuesCount"
+        },
+        {"type": "rank"},
+        {
+          "type": "formula",
+          "field": "yPos",
+          "expr": "<%= isNaN(height) ? '0' : height / 3 %> + 60 + datum.rank * 30"
+        },
+        {
+          "type": "formula",
+          "field": "xPos",
+          "expr": "0"
+        }
+      ]
+    },
+    {
+      "name": "rules",
+      "values": [
+        { "x": 10 },
+        { "x": 20 },
+        { "x": 30 },
+        { "x": 40 },
+        { "x": 50 },
+        { "x": 60 },
+        { "x": 70 },
+        { "x": 80 },
+        { "x": 90 },
+        { "x": 100 }
+      ]
+    },
+    {
+      "name": "final",
+      "source": "table",
+      "transform": [
+        {
+          "type": "stack",
+          "field": "percentage"
+        }
+      ]
+    }
+  ],
+  "scales": [
+    {
+      "name": "color",
+      "type": "ordinal",
+      "domain": {"data": "table","field": "label"},
+      "range": [
+        "#2f939c",
+        "#97c9ce",
+        "#001d22",
+        "#f9d031",
+        "#f95e31",
+        "#FCAE98",
+        "#633AE8",
+        "#E4D081",
+        "#00D9C6",
+        "#B9A86C",
+        "#7B0051",
+        "#B685C9",
+        "#076270",
+        "#8ADF70"
+      ]
+    },
+    {
+      "name": "stack",
+      "type": "linear",
+      "range": "width",
+      "domain": [0, 100]
+    }
+  ],
+  "marks": [
+    {
+      "type": "rule",
+      "properties": {
+        "enter": {
+          "x": {"value": 0, "scale": "stack"},
+          "y": {"field": {"group": "height"}, "mult": 0.1, "offset": -10},
+          "y2": {"value": 70},
+          "stroke": {"value": "#ccd2d3"}
+        }
+      }
+    },
+    {
+      "type": "rule",
+      "from": {"data": "rules"},
+      "properties": {
+        "enter": {
+          "x": {"field": "x", "scale": "stack"},
+          "y": {"field": {"group": "height"}, "mult": 0.1, "offset": -10},
+          "y2": {"value": 70},
+          "stroke": {"value": "#ccd2d3"}
+        }
+      }
+    },
+    {
+      "type": "text",
+      "from": {"data": "rules"},
+      "properties": {
+        "enter": {
+          "x": {"field": "x", "scale": "stack", "offset": -1},
+          "y": {"field": {"group": "height"}, "mult": 0.1, "offset": "50"},
+          "text": {"field": "x"},
+          "align": {"value": "right"},
+          "baseline": {"value": "bottom"},
+          "font": {"value": "Montserrat"},
+          "fontWeight": {"value": "300"},
+          "fontSize": {"value": 13},
+          "fill": {"value": "#001d22"}
+        }
+      }
+    },
+    {
+      "type": "rect",
+      "name": "hasTooltip",
+      "from": {"data": "final"},
+      "properties": {
+        "enter": {
+          "x": {"scale": "stack","field": "layout_start"},
+          "x2": {"scale": "stack","field": "layout_end"},
+          "y": {"field": {"group": "height"}, "mult": 0.1},
+          "height": {"value": 20},
+          "fill": {"scale": "color","field": "label"}
+        }
+      }
+    },
+    {
+      "type": "symbol",
+      "from": { "data": "legend" },
+      "properties": {
+        "enter": {
+          "x": {"field": "xPos", "offset": 6},
+          "y": {"field": "yPos"},
+          "size": {"value": 100},
+          "fill": {"scale": "color", "field": "a.label"}
+        }
+      }
+    },
+    {
+      "type": "text",
+      "from": { "data": "legend" },
+      "properties": {
+        "enter": {
+          "x": {"field": "xPos", "offset": 20},
+          "y": {"field": "yPos", "offset": 5},
+          "text": {"field": "a.label"},
+          "font": {"value": "Montserrat"},
+          "fontWeight": {"value": "300"},
+          "fontSize": {"value": 13},
+          "fill": {"value": "#001d22"}
+        }
+      }
+    }
+  ]
+}

--- a/app/assets/javascripts/views/data_portal/ChartTooltipView.js
+++ b/app/assets/javascripts/views/data_portal/ChartTooltipView.js
@@ -53,16 +53,51 @@
       var refX = rects.left;
       var refY = rects.top;
 
+      // Position of the click
       var x = e.clientX - refX;
       var y = e.clientY - refY;
 
+      // Translate values for the tooltip
+      var tooltipTranslateX = 'calc(' + x + 'px - 50%)';
+      var tooltipTranslateY = 'calc(' + y + 'px - 100%)';
+
+      // Translate values for the tip
+      var tipTranslateX = '-50%';
+      var tipTranslateY = '0';
+
       requestAnimationFrame(function () {
-        if (!this.options.visible) {
+        if (!this.options._visible) {
           this.el.style.display = 'block';
-          this.options.visible = true;
+          this.options._visible = true;
         }
 
-        this.el.style.transform = 'translate(calc(' + x + 'px - 50%), calc(' + y + 'px - 100%))';
+        // We compute the dimensions of the tooltip
+        // It needs to be done after it's been made visible
+        var tooltipRefs = this.el.getBoundingClientRect();
+
+        // Tooltip's position according to the click
+        var tooltipLeft = x - tooltipRefs.width / 2;
+        var tooltipRight = x + tooltipRefs.width / 2;
+
+        // Minimum and maximum value for the tooltip position
+        var leftLimit = 0;
+        var rightLimit = rects.width;
+
+        // If the tooltip is cut on its left edge
+        if (tooltipLeft < leftLimit) {
+          tooltipTranslateX = '' + leftLimit;
+          tipTranslateX = 'calc(-50% - ' + (-tooltipLeft) + 'px)';
+        }
+
+        // If the tooltip is cut on its right edge
+        if (tooltipRight > rightLimit) {
+          tooltipTranslateX = 'calc(' + rightLimit + 'px - 100%)';
+          tipTranslateX = 'calc(-50% - ' + (rightLimit - tooltipRight) + 'px)';
+        }
+
+        // We finally give their positions to the tooltip and the tip
+        this.el.style.transform = 'translate(' + tooltipTranslateX + ', ' + tooltipTranslateY + ')';
+        this.tip.style.transform = 'translate(' + tipTranslateX + ', ' + tipTranslateY + ') rotate(-45deg)';
       }.bind(this));
     },
 
@@ -83,6 +118,7 @@
       });
 
       this.options.reference.appendChild(this.el);
+      this.tip = this.el.querySelector('.js-tip');
     }
 
   });

--- a/app/assets/javascripts/views/data_portal/ChartWidgetView.js
+++ b/app/assets/javascripts/views/data_portal/ChartWidgetView.js
@@ -295,6 +295,13 @@
     },
 
     /**
+     * Event handler for when a chart receives a touchmove event
+     */
+    _onTouchmoveChart: function () {
+      this._onMouseoutChart();
+    },
+
+    /**
      * Event handler executed when the delete button is clicked
      */
     _onDelete: function () {
@@ -652,6 +659,7 @@
 
             this.chart.on('mouseover', this._onMouseoverChart.bind(this));
             this.chart.on('mouseout', this._onMouseoutChart.bind(this));
+            this.chart.on('touchmove', this._onTouchmoveChart.bind(this));
           }.bind(this));
       }
     },

--- a/app/assets/javascripts/views/data_portal/ChartWidgetView.js
+++ b/app/assets/javascripts/views/data_portal/ChartWidgetView.js
@@ -40,8 +40,12 @@
       report: false,
       // Callback executed when the delete button is clicked
       onDelete: function () {},
-      // Automatically resize the chart when the size of the window changes
-      // If false, then the chart is made "responsive" using the preserveAspectRatio attribute
+      // Automatically re-render the chart when the size of the window changes
+      // If false, the widget is scaled with the preserveAspectRatio attribute
+      // If true, it depends on the responsive mode of the widget:
+      //   * if adaptative, the widget is rendered with a different template according to its size
+      //   * if scroll, the widget is rendered as on desktop but with a horizontal scroll
+      //   * if no mode is provided, the desktop template is always chosen
       autoResize: true,
       // Default mode for widget view
       // The mode is used to determine how the toolbar should be shown
@@ -461,7 +465,7 @@
      */
     _getAvailableCharts: function () {
       return this.widgetToolbox.getAvailableCharts().filter(function (chartName) {
-        var chart = _.findWhere(App.Helper.ChartConfig, { name: chartName });
+        var chart = this._getChartConfig(chartName);
         return !chart.categories || chart.categories.indexOf(this._getIndicator().category) !== -1;
       }, this);
     },
@@ -491,11 +495,18 @@
       var chartTemplate = JSON.parse(this._getChartTemplate()({
         data: JSON.stringify([]),
         label: JSON.stringify(''),
-        width: JSON.stringify(''),
-        height: JSON.stringify('')
+        width: JSON.stringify(0),
+        height: JSON.stringify(0)
       }));
 
       var containerDimensions = this.chartContainer.getBoundingClientRect();
+      var chartConfig = this._getChartConfig();
+      var fixedWidth = false
+        || (chartConfig.responsive
+        && chartConfig.responsive.mode === 'scroll'
+        && containerDimensions.width < chartConfig.responsive.breakpoint);
+
+      this.chartContainer.classList[fixedWidth ? 'add' : 'remove']('-scroll');
 
       var padding = _.extend({}, chartTemplate.padding, {
         top: 0,
@@ -504,7 +515,7 @@
         left: 0
       });
 
-      var width = Math.round(containerDimensions.width - padding.left - padding.right);
+      var width = Math.round((fixedWidth ? 1024 : containerDimensions.width) - padding.left - padding.right);
       var height = Math.round(width * this._getChartRatio());
 
       // We save the current dimensions of the chart to diff them whenever the window is resized in order to minimize
@@ -521,12 +532,39 @@
     },
 
     /**
+     * Return whether the mobile template of the chart should be loaded
+     * @return {boolean}
+     */
+    _shouldLoadMobileTemplate: function () {
+      if (!this.options.autoResize) return false;
+
+      var chartContainer = this.chartContainer.getBoundingClientRect();
+      var chartConfig = this._getChartConfig();
+
+      if (!chartConfig.responsive || chartConfig.responsive.mode !== 'adaptative') return false;
+
+      return chartContainer.width < chartConfig.responsive.breakpoint;
+    },
+
+    /**
      * Get the chart Handlebars template
      * @returns {function}
      */
     _getChartTemplate: function () {
       var chartName = this.options.chart.replace(' ', '-');
-      return JST['templates/data_portal/widgets/' + chartName];
+      var responsive = this._shouldLoadMobileTemplate();
+      return JST['templates/data_portal/widgets/' + chartName + (responsive ? '-mobile' : '')];
+    },
+
+    /**
+     * Return the configuration a the chart
+     * If a chart name is provided, return the config of this chart, otherwise the
+     * config of the widget's chart
+     * @param {string} chartName name of the chart
+     * @return {object}
+     */
+    _getChartConfig: function (chartName) {
+      return _.findWhere(App.Helper.ChartConfig, { name: chartName || this.options.chart });
     },
 
     /**
@@ -534,7 +572,7 @@
      * @returns {number}
      */
     _getChartRatio: function () {
-      var chartConfig = _.findWhere(App.Helper.ChartConfig, { name: this.options.chart });
+      var chartConfig = this._getChartConfig();
       return (chartConfig && chartConfig.ratio) || this.options.chartRatio;
     },
 

--- a/app/assets/stylesheets/components/data-portal/c-chart-tooltip.scss
+++ b/app/assets/stylesheets/components/data-portal/c-chart-tooltip.scss
@@ -12,7 +12,7 @@
   text-align: center;
   box-shadow: 0 1px 2px 0 rgba($color-6, .09);
 
-  &::after {
+  > .tip {
     display: block;
     position: absolute;
     bottom: -7px;

--- a/app/assets/stylesheets/components/data-portal/c-chart-widget.scss
+++ b/app/assets/stylesheets/components/data-portal/c-chart-widget.scss
@@ -53,8 +53,9 @@
 
   > .toolbar {
     display: flex;
+    flex-wrap: wrap;
     justify-content: flex-start;
-    margin-top: 30px;
+    margin-top: 25px;
 
     @media #{$mq-tablet} {
       right: 30px;
@@ -62,8 +63,8 @@
       left: 30px;
     }
 
-    > .c-button:not(:last-child) {
-      margin: 0 5px 0 0;
+    > .c-button {
+      margin: 5px 5px 0 0;
     }
   }
 

--- a/app/assets/stylesheets/components/data-portal/c-chart-widget.scss
+++ b/app/assets/stylesheets/components/data-portal/c-chart-widget.scss
@@ -41,6 +41,7 @@
 
     svg {
       width: 100%;
+      -webkit-tap-highlight-color: rgba($color-6, 0);
     }
 
     &.-scroll {

--- a/app/assets/stylesheets/components/data-portal/c-chart-widget.scss
+++ b/app/assets/stylesheets/components/data-portal/c-chart-widget.scss
@@ -42,6 +42,13 @@
     svg {
       width: 100%;
     }
+
+    &.-scroll {
+      overflow-x: scroll;
+      -webkit-overflow-scrolling: touch;
+
+      svg { width: auto; }
+    }
   }
 
   > .toolbar {

--- a/app/assets/stylesheets/components/data-portal/c-widget.scss
+++ b/app/assets/stylesheets/components/data-portal/c-widget.scss
@@ -2,12 +2,13 @@
   position: relative;
   min-height: 200px;  // to keep a nice look
   margin: 0 0 30px;
-  padding: 30px;
+  padding: 15px;
   background: $color-4;
   box-shadow: 0 2px 3px 0 rgba($color-6, .15);
 
   @media #{$mq-tablet} {
     margin: 0 0 20px;
+    padding: 30px;
   }
 
   @media #{mq-laptop} {

--- a/app/assets/stylesheets/layouts/l-data-portal-country.scss
+++ b/app/assets/stylesheets/layouts/l-data-portal-country.scss
@@ -194,8 +194,32 @@
 
     .l-indicator-grid {
 
+      // We want the cards to have the same height and the wigdet's toolbar
+      // to be aligned at the bottom
       .widgets-list {
+        display: flex;
+        flex-wrap: wrap;
+        align-items: stretch;
         min-height: 500px;
+
+        > div {
+          margin-bottom: 20px;
+
+          > .c-widget {
+            height: 100%;
+            margin: 0;
+
+            > .c-chart-widget {
+              display: flex;
+              flex-direction: column;
+              height: 100%;
+
+              > .chart {
+                flex-grow: 1;
+              }
+            }
+          }
+        }
       }
 
       .footer-indicator-grid {


### PR DESCRIPTION
This PR make the widgets responsive.

The widgets can now be configured to render a different template depending on the viewport's width, to just re-render when the width changes or to be scaled down on smaller screen. As a consequence, some charts such as the pie one have now two templates.

Other changes include:
* forcing the widgets of a same row to have the same height, with the toolbar aligned at the bottom
* disabling the grey background on touch on the charts on iOS
* auto-closing the chart's tooltip when scrolling