### PR TITLE
Feature/data portal responsive

### DIFF
--- a/app/assets/javascripts/templates/data_portal/mobile-header.jst.ejs
+++ b/app/assets/javascripts/templates/data_portal/mobile-header.jst.ejs
@@ -1,0 +1,37 @@
+<% if (error || !indicators.length) { %>
+  <div class="wrapper">
+    <header>
+      <span class="country-name js-country">–</span>
+      <button type="button" class="js-mobile-header-toggle">Toggle menu</button>
+    </header>
+  </div>
+<% } else { %>
+  <div class="wrapper">
+    <header>
+      <span class="country-name js-country"><%= country %></span>
+      <button type="button" class="js-mobile-header-toggle">Toggle menu</button>
+    </header>
+    <div class="content">
+      <div class="l-data-range">
+        <span class="c-tag js-filter-tag" data-tab="context"><%= jurisdiction %></span>
+        in
+        <span class="c-tag js-filter-tag" data-tab="context"><%= year %></span>
+        <p>
+          Showing data about
+          <% indicators.forEach(function (indicator, index) { %>
+            <%= indicators.length > 1 && index === indicators.length - 1 ? 'and' : '' %> <span class="c-tag js-filter-tag" data-tab="indicator"><%= indicator.name %></span>
+          <% }) %>
+        </p>
+        <% if (filters.length) { %>
+          <p>
+            Filtered by
+            <% filters.forEach(function (filter, index) { %>
+              <%= filters.length > 1 && index === filters.length - 1 ? 'and' : '' %> <span class="c-tag js-filter-tag" data-tab="filter"><%= filter.name + ': ' + filter.options.join(', ') %></span>
+            <% }) %>
+          </p>
+        <% } %>
+      </div>
+      <button class="c-button -white js-customize-indicators">Customise indicators</button>
+    </div>
+  </div>
+<% } %>

--- a/app/assets/javascripts/templates/data_portal/table.jst.ejs
+++ b/app/assets/javascripts/templates/data_portal/table.jst.ejs
@@ -1,6 +1,6 @@
 <table role="grid" aria-readonly="true" aria-rowcount="<%= totalResults %>">
   <caption>
-    <%= tableName %>, sorted by <%= sortColumn %>: <%= sortOrder %>
+    <%= tableName %><% if (sortColumn) { %>, sorted by <%= sortColumn %>: <%= sortOrder %><% } %>
   </caption>
   <% if (error) { %>
     <tr class="error">

--- a/app/assets/javascripts/views/data_portal/ChartWidgetView.js
+++ b/app/assets/javascripts/views/data_portal/ChartWidgetView.js
@@ -637,7 +637,7 @@
 
         new App.View.TableView({
           el: this.chartContainer,
-          collection: new Backbone.Collection(this.model.get('data')),
+          collection: this.model.get('data'),
           tableName: this.model.get('title') + ' data',
           resultsPerPage: isComplex ? 10 : 3,
           resultsPerPageOptions: null

--- a/app/assets/javascripts/views/data_portal/tableView.js
+++ b/app/assets/javascripts/views/data_portal/tableView.js
@@ -73,7 +73,8 @@
       // This is computed at instantiation, do not set it from outside
       headers: null,
       // Column index used for sorting the table
-      sortColumnIndex: 0,
+      // -1 for no sorting
+      sortColumnIndex: -1,
       // Sort order: 1 for ASC, -1 for DESC
       sortOrder: 1,
       // Table name used by screen readers
@@ -290,7 +291,7 @@
         return collator.compare(valA, valB) * this.options.sortOrder;
       }.bind(this);
 
-      this.options.collection.sort();
+      if (this.options.sortColumnIndex !== -1) this.options.collection.sort();
     },
 
     /**
@@ -428,14 +429,17 @@
     },
 
     render: function () {
-      var sortColumn = this.options.headers.at(this.options.sortColumnIndex).attributes.name;
+      var sortColumn;
+      if (this.options.sortColumnIndex !== -1) {
+        sortColumn = this.options.headers.at(this.options.sortColumnIndex).attributes.name;
+      }
 
       var headers;
       if (this.options.collection.length) {
         headers = this.options.headers.toJSON()
           .map(function (column) {
             var sort;
-            if (column.name === sortColumn) {
+            if (sortColumn && column.name === sortColumn) {
               sort = this.options.sortOrder === 1 ? 'ascending' : 'descending';
             }
 

--- a/app/assets/javascripts/views/data_portal/tableView.js
+++ b/app/assets/javascripts/views/data_portal/tableView.js
@@ -50,9 +50,9 @@
       resultsPerPageOptions: [10, 25, 50, 100],
       // Current pagination index
       paginationIndex: 0,
-      // Collection representing the table
+      // Collection representing the table (not a Backone collection)
       // Each row can contain the name of the column, the value of the cell or an html content,
-      // a, attribute to tell if the column can be searchable and another to tell if it's sortable
+      // an attribute to tell if the column can be searchable and another to tell if it's sortable
       // The value attribute can have an array of strings
       // An optional link attribute can be present, it contains its url and an attribute to tell
       // if the link is external or not (this is not built for multi-value cells)
@@ -67,7 +67,7 @@
       //     ]
       //   }
       // ]
-      // NOTE: the collection will be added a comparator function and methods
+      // NOTE: don't directly call this value, use _getCollection instead
       collection: null,
       // List of headers
       // This is computed at instantiation, do not set it from outside
@@ -98,50 +98,33 @@
     initialize: function (settings) {
       this.options = Object.assign({}, this.defaults, settings);
 
-      if (!this.options.collection) {
-        throw new Error('Please provide to the table component a collection to fetch.');
+      if (!this.options.collection || !this.options.collection.length) {
+        throw new Error('Please provide a collection to the table component.');
       }
 
       if (!this.options.tableName || !this.options.tableName.length) {
         throw new Error('Please provide a name to the table component.');
       }
 
-      // Callback executed when the collection has data
-      var done = function () {
-        this.options.headers = new HeadersCollection(this.options.collection.toJSON(), { parse: true });
-        this._initSort();
-        if (this.options.searchFieldContainer) this._initSearch();
-        this.render();
-      };
-
-      if (this.options.collection.length > 0) {
-        done.call(this);
-      } else if (!this.options.collection.url) {
-        // eslint-disable-next-line no-console
-        console.warn('The table has been instanciated with an empty collection and no url to fetch the data has been provided.');
-        return;
-      } else {
-        this.options.collection.fetch()
-          .done(done.bind(this))
-          .fail(function () {
-            this.error = 'Unable to load the data for the table.';
-            this.render();
-          }.bind(this));
-      }
+      this.options.headers = new HeadersCollection(this._getCollection(), { parse: true });
+      this._initSort();
+      if (this.options.searchFieldContainer) this._initSearch();
+      this.render();
     },
 
     /**
      * Set global variables
      */
     _setVars: function () {
-      this.$headers = this.$('.js-header > th');
+      this.$headersContainer = this.$('.js-header');
+      this.$headers = this.$headersContainer.children();
     },
 
     /**
      * Set the listeners on the rendered DOM
      */
     _setListeners: function () {
-      this.$('.js-header').on('click', function (e) {
+      this.$headersContainer.on('click', function (e) {
         // We need to move the user to the first page of results
         // NOTE: it needs to be placed before the actual sort so that when the table
         // is rendered, the page is resetted
@@ -151,7 +134,7 @@
         if (column) this._sortTable(column);
       }.bind(this));
 
-      this.$('.js-header').on('keydown', this._onKeydownHeader.bind(this));
+      this.$headersContainer.on('keydown', this._onKeydownHeader.bind(this));
 
       this.$('.js-more').on('click', this._onClickMore.bind(this));
 
@@ -263,9 +246,9 @@
     _initSort: function () {
       var collator = new Intl.Collator([], { sensitivity: 'base' });
 
-      this.options.collection.comparator = function (modelA, modelB) {
-        var cellA = modelA.attributes.row[this.options.sortColumnIndex];
-        var cellB = modelB.attributes.row[this.options.sortColumnIndex];
+      this.options.compareFunction = function (modelA, modelB) {
+        var cellA = modelA.row[this.options.sortColumnIndex];
+        var cellB = modelB.row[this.options.sortColumnIndex];
 
         var valA = Array.isArray(cellA.value) ? cellA.value[0] : cellA.value;
         var valB = Array.isArray(cellB.value) ? cellB.value[0] : cellB.value;
@@ -291,7 +274,60 @@
         return collator.compare(valA, valB) * this.options.sortOrder;
       }.bind(this);
 
-      if (this.options.sortColumnIndex !== -1) this.options.collection.sort();
+      if (this.options.sortColumnIndex !== -1) this.options.collection.sort(this.options.compareFunction);
+    },
+
+    /**
+     * Return the value of the collection
+     * @returns {object[]}
+     */
+    _getCollection: function () {
+      var collection = this.options.collection;
+      if (!this.options.searchQuery || !this.options.searchQuery.length) return collection;
+
+      // Each time, we need to recreate an instance of Fuse to maintain the sorting of the table
+      var searchableColumns = this.options.headers.toJSON()
+        .filter(function (header) { return header.searchable; })
+        .map(function (header) { return header.name; });
+
+      // We need to format the data for Fuse
+      // The basic idea is that Fuse has a direct access to the searchable columns and their value.
+      // We maintain a reference to the original row so we can display it later
+      // Example of the format:
+      // [
+      //   {
+      //     row: [
+      //      { name: 'Title', value: 'Vizzuality' },
+      //      { name: 'Price', value: '100€' }
+      //     ],
+      //     Title: 'Vizzuality',
+      //     Price: '100€'
+      //   }
+      // ]
+      var fuseCollection = collection.map(function (row) {
+        var o = {};
+        o.row = row;
+        for (var i = 0, j = searchableColumns.length; i < j; i++) {
+          var value = _.findWhere(row.row, { name: searchableColumns[i] }).value;
+          o[searchableColumns[i]] = value;
+        }
+        return o;
+      });
+
+      var fuse = new Fuse(fuseCollection, {
+        include: ['matches'],
+        keys: searchableColumns,
+        tokenize: true,
+        threshold: 0.1,
+        matchAllTokens: true,
+        shouldSort: false
+      });
+
+      var searchResults = fuse.search(this.options.searchQuery);
+
+      return searchResults.map(function (result) {
+        return result.item.row;
+      });
     },
 
     /**
@@ -327,56 +363,6 @@
       this.options.searchFieldContainer.innerHTML = ''; // We make sure the container is empty
       this.options.searchFieldContainer.appendChild(searchField);
       this.options.searchFieldContainer.appendChild(searchButton);
-
-      // We modify the toJSON method to take into account the search query
-      this.options.collection.toJSON = function (options) {
-        var collection = Backbone.Collection.prototype.toJSON.call(this.options.collection, options);
-        if (!this.options.searchQuery || !this.options.searchQuery.length) return collection;
-
-        // Each time, we need to recreate an instance of Fuse to maintain the sorting of the table
-        var searchableColumns = this.options.headers.toJSON()
-          .filter(function (header) { return header.searchable; })
-          .map(function (header) { return header.name; });
-
-        // We need to format the data for Fuse
-        // The basic idea is that Fuse has a direct access to the searchable columns and their value.
-        // We maintain a reference to the original row so we can display it later
-        // Example of the format:
-        // [
-        //   {
-        //     row: [
-        //      { name: 'Title', value: 'Vizzuality' },
-        //      { name: 'Price', value: '100€' }
-        //     ],
-        //     Title: 'Vizzuality',
-        //     Price: '100€'
-        //   }
-        // ]
-        var fuseCollection = collection.map(function (row) {
-          var o = {};
-          o.row = row;
-          for (var i = 0, j = searchableColumns.length; i < j; i++) {
-            var value = _.findWhere(row.row, { name: searchableColumns[i] }).value;
-            o[searchableColumns[i]] = value;
-          }
-          return o;
-        });
-
-        this.options.collection.fuse = new Fuse(fuseCollection, {
-          include: ['matches'],
-          keys: searchableColumns,
-          tokenize: true,
-          threshold: 0.1,
-          matchAllTokens: true,
-          shouldSort: false
-        });
-
-        var searchResults = this.options.collection.fuse.search(this.options.searchQuery);
-
-        return searchResults.map(function (result) {
-          return result.item.row;
-        });
-      }.bind(this);
     },
 
     /**
@@ -398,7 +384,7 @@
         this.options.sortColumnIndex = columnIndex;
       }
 
-      this.options.collection.sort();
+      this.options.collection.sort(this.options.compareFunction);
       this.render();
     },
 
@@ -419,13 +405,13 @@
       var start = this.options.resultsPerPage * this.options.paginationIndex;
       var end = this.options.resultsPerPage * (this.options.paginationIndex + 1);
 
-      return this.options.collection.toJSON()
+      return this._getCollection()
+        .slice(start, end)
         .map(function (row, index) {
           // The rowIndex value is used for accessibility
           // The index needs to start at 2 because the header row is 1
           return Object.assign({}, row.row, { rowIndex: index + 2 });
-        })
-        .slice(start, end);
+        });
     },
 
     render: function () {
@@ -459,9 +445,9 @@
         columnCount: headers.length,
         resultsPerPage: this.options.resultsPerPage,
         resultsPerPageOptions: this.options.resultsPerPageOptions,
-        firstResultIndex: this.options.collection.toJSON().length ? (this.options.resultsPerPage * this.options.paginationIndex) + 1 : 0,
-        lastResultIndex: Math.min(this.options.resultsPerPage * (this.options.paginationIndex + 1), this.options.collection.toJSON().length),
-        totalResults: this.options.collection.toJSON().length,
+        firstResultIndex: this._getCollection().length ? (this.options.resultsPerPage * this.options.paginationIndex) + 1 : 0,
+        lastResultIndex: Math.min(this.options.resultsPerPage * (this.options.paginationIndex + 1), this._getCollection().length),
+        totalResults: this._getCollection().length,
         rows: this._getRenderableRows(),
         sortColumn: sortColumn,
         sortOrder: this.options.sortOrder === 1 ? 'ascending' : 'descending',

--- a/app/assets/javascripts/views/data_portal/tableView.js
+++ b/app/assets/javascripts/views/data_portal/tableView.js
@@ -260,11 +260,11 @@
      * Set the comparator to the table's first column and sort the collection
      */
     _initSort: function () {
-      this.options.collection.comparator = function (modelA, modelB) {
-        var comparator = this.options.headers.at(this.options.sortColumnIndex).attributes.name;
+      var collator = new Intl.Collator([], { sensitivity: 'base' });
 
-        var cellA = _.findWhere(modelA.attributes.row, { name: comparator });
-        var cellB = _.findWhere(modelB.attributes.row, { name: comparator });
+      this.options.collection.comparator = function (modelA, modelB) {
+        var cellA = modelA.attributes.row[this.options.sortColumnIndex];
+        var cellB = modelB.attributes.row[this.options.sortColumnIndex];
 
         var valA = Array.isArray(cellA.value) ? cellA.value[0] : cellA.value;
         var valB = Array.isArray(cellB.value) ? cellB.value[0] : cellB.value;
@@ -287,7 +287,7 @@
           return this.options.sortOrder;
         }
 
-        return valA.localeCompare(valB, [], { sensitivity: 'base' }) * this.options.sortOrder;
+        return collator.compare(valA, valB) * this.options.sortOrder;
       }.bind(this);
 
       this.options.collection.sort();

--- a/app/assets/stylesheets/components/shared/c-newsletter-section.scss
+++ b/app/assets/stylesheets/components/shared/c-newsletter-section.scss
@@ -2,9 +2,17 @@
   padding: 30px 0;
   background-color: $color-5;
   color: $color-4;
+  line-height: 1.38;
 
   .c-button {
-    margin-left: 25px;
+    display: block;
+    margin-top: 10px;
+
+    @media #{$mq-tablet} {
+      display: inline-block;
+      margin-top: 0;
+      margin-left: 25px;
+    }
   }
 
   .subscribe-button-inner {

--- a/app/assets/stylesheets/layouts/l-data-portal-country.scss
+++ b/app/assets/stylesheets/layouts/l-data-portal-country.scss
@@ -10,26 +10,78 @@
     right: 0;
     left: 0;
     padding: 15px 0;
-
     background: $color-1;
     box-shadow: 0 2px 3px 0 rgba($color-6, .15);
-    z-index: 10;
+    z-index: 1;
 
-    .country-name {
-      display: block;
+    header {
+      display: flex;
       position: relative;
+      align-items: center;
+      justify-content: space-between;
 
-      color: $color-4;
-      font-family: $font-family-2;
-      font-size: $font-size-xs;
+      .country-name {
+        display: block;
+        position: relative;
+        color: $color-4;
+        font-family: $font-family-2;
+        font-size: $font-size-xs;
+      }
 
-      &::after {
+      button {
         @include arrow(8px, 2px, $color-4, 'down');
-        position: absolute;
-        top: calc(50% - 4px);
-        right: 0;
-        transform: rotate(45deg) translate(0, -50%);
+        padding: 0;
+        transform: translate(-3px, -50%) rotate(45deg);
+        text-indent: -10000px;
         cursor: pointer;
+      }
+    }
+
+    .content {
+      display: none;
+      margin-top: 25px;
+
+      .l-data-range p {
+        margin-top: 10px;
+      }
+
+      .c-button {
+        width: 100%;
+        margin-top: 70px;
+      }
+    }
+
+    &.-open {
+      header {
+        button {
+          transform: translate(-3px, calc(-50% + 5px)) rotate(-135deg);
+        }
+      }
+
+      .content {
+        display: block;
+      }
+    }
+  }
+
+  .l-data-range {
+    margin: 25px 0 20px;
+    color: $color-3;
+    font-family: $font-family-2;
+    font-size: $font-size-xs;
+    line-height: 1.8;
+
+    @media #{$mq-laptop} {
+      margin: 20px 0 0;
+    }
+
+    p {
+      color: $color-3;
+      font-family: $font-family-2;
+      line-height: 1.8;
+
+      &:not(:first-child) {
+        margin: 5px 0 0;
       }
     }
   }
@@ -107,28 +159,6 @@
       .number {
         font-size: $font-size-xm;
         letter-spacing: -1px;
-      }
-    }
-
-    .l-data-range {
-      margin: 25px 0 20px;
-      color: $color-3;
-      font-family: $font-family-2;
-      font-size: $font-size-xs;
-      line-height: 1.8;
-
-      @media #{$mq-laptop} {
-        margin: 20px 0 0;
-      }
-
-      p {
-        color: $color-3;
-        font-family: $font-family-2;
-        line-height: 1.8;
-
-        &:not(:first-child) {
-          margin: 5px 0 0;
-        }
       }
     }
 

--- a/app/assets/stylesheets/layouts/l-data-portal-country.scss
+++ b/app/assets/stylesheets/layouts/l-data-portal-country.scss
@@ -112,15 +112,14 @@
 
     .l-data-range {
       margin: 25px 0 20px;
-
-      @media #{$mq-laptop} {
-        margin: 20px 0 0;
-      }
-
       color: $color-3;
       font-family: $font-family-2;
       font-size: $font-size-xs;
       line-height: 1.8;
+
+      @media #{$mq-laptop} {
+        margin: 20px 0 0;
+      }
 
       p {
         color: $color-3;
@@ -144,7 +143,12 @@
         }
 
         .c-button {
-          margin: 40px 0 25px;
+          width: 100%;
+
+          @media #{$mq-tablet} {
+            width: auto;
+            margin: 40px 0 25px;
+          }
         }
       }
 

--- a/app/assets/stylesheets/layouts/shared/l-header.scss
+++ b/app/assets/stylesheets/layouts/shared/l-header.scss
@@ -1,5 +1,7 @@
-
 .l-header {
-  padding: 0 0 25px;
   background: $color-1;
+
+  @media #{$mq-tablet} {
+    padding: 0 0 25px;
+  }
 }

--- a/app/views/data_portal/show.html.erb
+++ b/app/views/data_portal/show.html.erb
@@ -5,9 +5,12 @@
 <% title 'Data Portal' %>
 
 <div class="l-data-portal-country">
-  <div class="l-mobile-header _no-desktop">
+  <div class="l-mobile-header _no-desktop js-mobile-header">
     <div class="wrapper">
-      <span class="country-name js-country">–</span>
+      <header>
+        <span class="country-name js-country">–</span>
+        <button type="button" class="js-mobile-header-toggle">Toggle menu</button>
+      </header>
     </div>
   </div>
   <div class="l-header">

--- a/app/views/data_portal/show.html.erb
+++ b/app/views/data_portal/show.html.erb
@@ -27,8 +27,8 @@
       <div class="l-switcher _no-desktop">
         <div class="grid-s-8 grid-m-4 grid-l-3">
           <div class="c-switcher js-tabs" role="tablist">
-            <button id="graphics-tab" class="switcher-option -current" role="tab" aria-controls="widgets-list" aria-selected="true"Graphics</button>
-            <button id="table-tab" class="switcher-option" role="tab" aria-controls="widgets-list" aria-selected="false" tabindex="-1">Table</button>
+            <button id="graphics-tab" class="switcher-option -current" name="graphics" role="tab" aria-controls="widgets-list" aria-selected="true">Graphics</button>
+            <button id="table-tab" class="switcher-option" name="table" role="tab" aria-controls="widgets-list" aria-selected="false" tabindex="-1">Table</button>
           </div>
         </div>
       </div>

--- a/app/views/data_portal/show.html.erb
+++ b/app/views/data_portal/show.html.erb
@@ -26,13 +26,11 @@
         </div>
       </div>
     </div>
-    <div class="row">
-      <div class="l-switcher _no-desktop">
-        <div class="grid-s-8 grid-m-4 grid-l-3">
-          <div class="c-switcher js-tabs" role="tablist">
-            <button id="graphics-tab" class="switcher-option -current" name="graphics" role="tab" aria-controls="widgets-list" aria-selected="true">Graphics</button>
-            <button id="table-tab" class="switcher-option" name="table" role="tab" aria-controls="widgets-list" aria-selected="false" tabindex="-1">Table</button>
-          </div>
+    <div class="l-switcher _no-desktop">
+      <div class="grid-s-8 grid-m-4 grid-l-3">
+        <div class="c-switcher js-tabs" role="tablist">
+          <button id="graphics-tab" class="switcher-option -current" name="graphics" role="tab" aria-controls="widgets-list" aria-selected="true">Graphics</button>
+          <button id="table-tab" class="switcher-option" name="table" role="tab" aria-controls="widgets-list" aria-selected="false" tabindex="-1">Table</button>
         </div>
       </div>
     </div>


### PR DESCRIPTION
This PR makes the portal's layout responsive: some broken layouts have been fixed and a mobile menu has been added to change the filters of the portal.

In addition, the table component has been refactored because it would freeze the browser during several seconds on mobile. As a result, the tables render 3 times faster on mobile (10X CPU slowdown on Chrome).

The performance results are achieved by:
* creating a [collator](!mdn collateral) for the localeCompare (compare) function (thanks to [this post](https://bugs.chromium.org/p/chromium/issues/detail?id=170864#c5))
* removing the default sorting of the table (i.e. the tables are sorted only if the user asks for it)
* replacing the Backbone collection of the tables by native objects

These changes reduced the JS computations by 70X 💨💨💨.