### PR TITLE
Feature/event documents

### DIFF
--- a/app/admin/event.rb
+++ b/app/admin/event.rb
@@ -47,7 +47,9 @@ ActiveAdmin.register Event do
     end
 
     def permitted_params
-      params.permit(:id, event: [:title, :author, :url, :summary, :content, :id, :image, :date, :published, :custom_author])
+      params.permit(:id, event: [:title, :author, :url, :summary, :content, :id, :image, :date, :published, :custom_author,
+                                 documents_attributes: [:file, :name, :id, :_destroy],
+                                 documented_items_attributes: [:document_id, :id, :_destroy]])
     end
   end
 
@@ -74,6 +76,11 @@ ActiveAdmin.register Event do
       f.input :summary
       f.input :content, as: :ckeditor, input_html: { ckeditor: { height: 400 } }
       f.input :date, as: :date_picker
+      f.has_many :documents, allow_destroy: true, new_record: true, heading: 'Documents' do |a|
+        a.input :name
+        a.input :file, as: :file, allow_destroy: true, hint: a.object.file.present? ? \
+          "#{a.object.file_file_name}" : content_tag(:span, 'No PDF yet')
+      end
       f.input :image, as: :file, hint: f.object.image.present? ? \
         image_tag(f.object.image.url(:thumb)) : content_tag(:span, 'No image yet')
       # Will preview the image when the object is edited
@@ -97,6 +104,15 @@ ActiveAdmin.register Event do
       row :url
       row :summary
       row :content
+      row :documents do
+        if ad.documents.present?
+          links = ad.documents.map do |document|
+            link_to document.file_file_name, request.base_url + document.file.url
+          end.join(', ')
+
+          raw links
+        end
+      end
       row :image do
         image_tag(ad.image.url(:thumb)) unless ad.image.blank?
       end

--- a/app/assets/stylesheets/components/updates/c-article.scss
+++ b/app/assets/stylesheets/components/updates/c-article.scss
@@ -114,6 +114,19 @@
         li + li {
           margin-top: 25px;
         }
+
+        &.link-list {
+          padding: 0;
+          margin: 2em 0;
+
+          > .link-item {
+            list-style: none;
+
+            & + .link-item {
+              margin-top: 15px;
+            }
+          }
+        }
       }
 
       ul li { list-style: disc; }

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -23,6 +23,10 @@ class Event < ApplicationRecord
   extend FriendlyId
   friendly_id :title, use: [:slugged, :finders]
   has_attached_file :image, styles: {thumb: '300x300>'}
+  has_many :documents, :through => :documented_items
+  accepts_nested_attributes_for :documents, allow_destroy: true
+  has_many :documented_items, :as => :documentable, :dependent => :destroy
+  accepts_nested_attributes_for :documented_items, allow_destroy: true
 
   after_initialize :set_date
 

--- a/app/views/updates/events/show.html.erb
+++ b/app/views/updates/events/show.html.erb
@@ -51,6 +51,19 @@
                       <%= @event.content.html_safe %>
                     </div>
                   </div>
+
+                  <div class="article-text">
+                    <div class="grid-s-12 grid-m-10 grid-l-8">
+                      <% if @event.documents.present? %>
+                        <ul class="link-list">
+                          <% @event.documents.each do |document| %>
+                            <li class="link-item"><a href="<%= document.file.url %>" target="_blank" rel="noopener" class="title -sea -small js-download" data-name="<%= document.name %>">Download <%= document.name %></a></li>
+                          <% end %>
+                        </ul>
+                      <% end %>
+                    </div>
+                  </div>
+
                   <% if @event.url.blank? != true %>
                     <div class="grid-s-12 grid-m-10 grid-l-12">
                       <div class="footer-article">


### PR DESCRIPTION
Now user can upload many PDFs to the event.

The PDFs will show up for download on the event details as a list on the bottom with the name added by the user on the CMS and not by the name of the document itself.