### PR TITLE
Feature/library documents

### DIFF
--- a/app/admin/library.rb
+++ b/app/admin/library.rb
@@ -23,8 +23,8 @@ ActiveAdmin.register Library do
                               :image, :date, :url_resource,
                               :video_url, :subcategory_id, :issuu_link,
                               tagged_items_attributes: [:tag_id, :id, :_destroy],
-                              documents_attributes: [:file, :name, :id, :_destroy],
-                              documented_items_attributes: [:document_id, :id, :_destroy]
+                              document_attributes: [:file, :name, :id, :_destroy],
+                              documented_item_attributes: [:document_id, :id, :_destroy]
       ]
     end
   end
@@ -66,11 +66,15 @@ ActiveAdmin.register Library do
       f.input :image, as: :file, hint: f.object.image.present? ? \
         image_tag(f.object.image.url(:thumb)) : content_tag(:span, 'No image yet')
       f.input :issuu_link
-      f.has_many :documents, allow_destroy: true, new_record: true, heading: 'Documents' do |a|
-      	a.input :name
-      	a.input :file, as: :file, allow_destroy: true, hint: a.object.file.present? ? \
-        	"#{a.object.file_file_name}" : content_tag(:span, 'No PDF yet')
+
+      f.inputs "Document", for: [:document, f.object.document || create_document(f)] do |s|
+        s.input :name
+        s.input :file, as: :file, allow_destroy: true, hint: s.object.file.present? ? \
+          "#{s.object.file_file_name}" : content_tag(:span, 'No PDF yet')
+
+        s.input :_destroy, as: :boolean
       end
+
       # Will preview the image when the object is edited
       li "Created at #{f.object.created_at}" unless f.object.new_record?
       li "Updated at #{f.object.updated_at}" unless f.object.new_record?
@@ -91,13 +95,9 @@ ActiveAdmin.register Library do
       	ActiveAdminHelper.tags_names(ad.tags)
       end
       row :issuu_link
-      row :documents do
-      	if ad.documents.present?
-					links = ad.documents.map do |document|
-						link_to document.file_file_name, request.base_url + document.file.url
-					end.join(', ')
-
-					raw links
+      row :document do
+        if ad.document.present?
+					raw link_to ad.document.file_file_name, request.base_url + ad.document.file.url
 				end
       end
       row :image do

--- a/app/helpers/active_admin_helper.rb
+++ b/app/helpers/active_admin_helper.rb
@@ -6,4 +6,12 @@ module ActiveAdminHelper
   def self.format_date(date)
     date.strftime("%B %d, %Y")
   end
+
+  def create_document(f)
+    new_document = f.object.build_documented_item.build_document
+
+    new_document.documented_items << f.object.build_documented_item
+    new_document.save
+    new_document
+  end
 end

--- a/app/models/library.rb
+++ b/app/models/library.rb
@@ -33,10 +33,10 @@ class Library < ApplicationRecord
   has_many :tags, :through => :tagged_items
   accepts_nested_attributes_for :tagged_items, allow_destroy: true
 
-  has_many :documents, :through => :documented_items
-  accepts_nested_attributes_for :documents, allow_destroy: true
-  has_many :documented_items, :as => :documentable, :dependent => :destroy
-  accepts_nested_attributes_for :documented_items, allow_destroy: true
+  has_one :documented_item, as: :documentable
+  has_one :document, through: :documented_item
+  accepts_nested_attributes_for :documented_item, allow_destroy: true
+  accepts_nested_attributes_for :document, allow_destroy: true
 
   after_initialize :set_date
 


### PR DESCRIPTION
Changed the relationship of library from has many documents to a has one document. Since the join table is a polymorphic table, some adjustments has to be made: using a document form inside the library form and also creating the document beforehand from a helper method, otherwise the relationship can't be made.

Creating the document beforehand made it impossible to create the library with a document already, so the document can only be added once the library is created.


Changed the url_resource field to update automatically with the document url.