### PR TITLE
Prevent nav collapsing for older versions of Safari on tablet

### DIFF
--- a/app/assets/stylesheets/components/shared/c-header.scss
+++ b/app/assets/stylesheets/components/shared/c-header.scss
@@ -1,8 +1,5 @@
 .c-header {
-  display: flex;
-  flex-wrap: wrap;
-  align-items: center;
-  justify-content: space-between;
+  position: relative;
   width: 100%;
   height: auto;
   // margin-top: 10px;

--- a/app/assets/stylesheets/components/shared/c-nav.scss
+++ b/app/assets/stylesheets/components/shared/c-nav.scss
@@ -2,8 +2,7 @@
   display: none;
 
   @media #{$mq-laptop} {
-    display: block;
-    // height: 100%;
+    display: flex;
   }
 
   &.-footer {
@@ -13,7 +12,6 @@
   > .nav-list {
     display: flex;
     align-items: center;
-    height: 100%;
 
     > .nav-item {
       display: flex;


### PR DESCRIPTION
Closes https://www.pivotaltracker.com/story/show/152591539