### PR TITLE
Feature/position menu

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -44,6 +44,8 @@ gem 'dotenv-rails', '~> 2.1'
 
 gem 'activeadmin', github: 'activeadmin'
 gem 'devise'
+gem 'acts_as_list'
+gem 'activeadmin-sortable'
 
 # File upload gems
 gem 'paperclip'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -66,6 +66,8 @@ GEM
       activemodel (>= 4.1, < 6)
       case_transform (>= 0.2)
       jsonapi-renderer (>= 0.1.1.beta1, < 0.2)
+    activeadmin-sortable (0.0.3)
+      activeadmin (>= 0.4)
     activejob (5.0.4)
       activesupport (= 5.0.4)
       globalid (>= 0.3.6)
@@ -82,6 +84,8 @@ GEM
       i18n (~> 0.7)
       minitest (~> 5.1)
       tzinfo (~> 1.1)
+    acts_as_list (0.9.10)
+      activerecord (>= 3.0)
     addressable (2.5.1)
       public_suffix (~> 2.0, >= 2.0.2)
     airbrussh (1.3.0)
@@ -392,8 +396,10 @@ PLATFORMS
 DEPENDENCIES
   active_model_serializers (~> 0.10.0)
   activeadmin!
+  activeadmin-sortable
   activerecord-import (~> 0.15.0)
   activerecord-session_store!
+  acts_as_list
   annotate
   autoprefixer-rails (~> 6.7)
   bcrypt (~> 3.1.7)

--- a/app/admin/blog.rb
+++ b/app/admin/blog.rb
@@ -55,7 +55,8 @@ ActiveAdmin.register Blog do
     def permitted_params
       params.permit(:id, blog: [:title, :author, :workstream, :summary, :content, :id, :image, :date,
                     :issuu_link, :published, :custom_author, :category_id, :is_featured, :position,
-                    tagged_items_attributes: [:tag_id, :id, :_destroy]])
+                    tagged_items_attributes: [:tag_id, :id, :_destroy],
+                    featured_position_attributes: [:id, :position, :_destroy]])
     end
   end
 
@@ -87,7 +88,9 @@ ActiveAdmin.register Blog do
       f.input :custom_author, placeholder: 'This will take priority over author.'
       f.input :published
       f.input :is_featured
-      f.input :position, placeholder: 'For featured'
+      f.has_many :featured_position, allow_destroy: true, new_record: true, heading: 'Position (only for featured)' do |a|
+        a.input :position
+      end
       f.input :workstream
       f.input :summary
       f.input :content, as: :ckeditor, input_html: { ckeditor: { height: 400 } }
@@ -114,7 +117,9 @@ ActiveAdmin.register Blog do
       row :custom_author
       row :published
       row :is_featured
-      row :position
+      row :position do
+        ActiveAdminHelper.position(ad.featured_position)
+      end
       row :workstream
       row :summary
       row :tags do

--- a/app/admin/event.rb
+++ b/app/admin/event.rb
@@ -57,7 +57,8 @@ ActiveAdmin.register Event do
                                  :published, :custom_author, :category_id, :is_featured, :position,
                                  documents_attributes: [:file, :name, :id, :_destroy],
                                  tagged_items_attributes: [:tag_id, :id, :_destroy],
-                                 documented_items_attributes: [:document_id, :id, :_destroy]])
+                                 documented_items_attributes: [:document_id, :id, :_destroy],
+                                 featured_position_attributes: [:id, :position, :_destroy]])
     end
   end
 
@@ -87,7 +88,9 @@ ActiveAdmin.register Event do
       f.input :custom_author, placeholder: 'This will take priority over author.'
       f.input :published
       f.input :is_featured
-      f.input :position, placeholder: 'For featured'
+      f.has_many :featured_position, allow_destroy: true, new_record: true, heading: 'Position (only for featured)' do |a|
+        a.input :position
+      end
       f.input :url
       f.input :summary
       f.input :content, as: :ckeditor, input_html: { ckeditor: { height: 400 } }
@@ -123,7 +126,9 @@ ActiveAdmin.register Event do
       row :custom_author
       row :published
       row :is_featured
-      row :position
+      row :position do
+        ActiveAdminHelper.position(ad.featured_position)
+      end
       row :url
       row :summary
       row :tags do

--- a/app/admin/featured_position.rb
+++ b/app/admin/featured_position.rb
@@ -1,8 +1,9 @@
 ActiveAdmin.register FeaturedPosition do
-  config.per_page = 20
   config.sort_order = 'position_asc'
 
-  actions  :index, :edit, :show, :update, :destroy
+  actions  :index, :show, :destroy
+
+  sortable
 
   controller do
     def permitted_params
@@ -11,6 +12,7 @@ ActiveAdmin.register FeaturedPosition do
   end
 
   index do
+    sortable_handle_column
     selectable_column
     column :positionable
     column :position

--- a/app/admin/featured_position.rb
+++ b/app/admin/featured_position.rb
@@ -1,0 +1,33 @@
+ActiveAdmin.register FeaturedPosition do
+  config.per_page = 20
+  config.sort_order = 'position_asc'
+
+  actions  :index, :edit, :show, :update, :destroy
+
+  controller do
+    def permitted_params
+      params.permit(:id, featured_position: [:position])
+    end
+  end
+
+  index do
+    selectable_column
+    column :positionable
+    column :position
+    column :positionable_type
+    column :updated_at
+    column :created_at
+    actions
+  end
+
+  form multipart: true do |f|
+    f.semantic_errors *f.object.errors.keys
+    f.inputs 'Blog details' do
+      f.input :position
+      li "Created at #{f.object.created_at}" unless f.object.new_record?
+      li "Updated at #{f.object.updated_at}" unless f.object.new_record?
+    end
+    f.actions
+  end
+
+end

--- a/app/admin/library.rb
+++ b/app/admin/library.rb
@@ -35,7 +35,8 @@ ActiveAdmin.register Library do
                               :video_url, :issuu_link, :position, :description,
                               tagged_items_attributes: [:tag_id, :id, :_destroy],
                               document_attributes: [:file, :name, :id, :_destroy],
-                              documented_item_attributes: [:document_id, :id, :_destroy]
+                              documented_item_attributes: [:document_id, :id, :_destroy],
+                              featured_position_attributes: [:id, :position, :_destroy]
       ]
     end
   end
@@ -65,7 +66,9 @@ ActiveAdmin.register Library do
       f.input :title
       f.input :published
       f.input :is_featured
-      f.input :position, placeholder: 'For featured'
+      f.has_many :featured_position, allow_destroy: true, new_record: true, heading: 'Position (only for featured)' do |a|
+        a.input :position
+      end
       f.input :summary
       f.input :description
       f.input :date, as: :date_picker
@@ -124,7 +127,9 @@ ActiveAdmin.register Library do
       row :title
       row :published
       row :is_featured
-      row :position
+      row :position do
+        ActiveAdminHelper.position(ad.featured_position)
+      end
       row :summary
       row :description
       row :tags do

--- a/app/admin/news.rb
+++ b/app/admin/news.rb
@@ -56,7 +56,8 @@ ActiveAdmin.register News do
     def permitted_params
       params.permit(:id, news: [:title, :author, :summary, :content, :id, :image, :date, :issuu_link,
                                 :published, :category_id, :is_featured, :position,
-                                tagged_items_attributes: [:tag_id, :id, :_destroy]])
+                                tagged_items_attributes: [:tag_id, :id, :_destroy],
+                                featured_position_attributes: [:id, :position, :_destroy]])
     end
   end
 
@@ -84,7 +85,9 @@ ActiveAdmin.register News do
       f.input :title
       f.input :published
       f.input :is_featured
-      f.input :position, placeholder: 'For featured'
+      f.has_many :featured_position, allow_destroy: true, new_record: true, heading: 'Position (only for featured)' do |a|
+        a.input :position
+      end
       f.input :summary
       f.input :content, as: :ckeditor, input_html: { ckeditor: { height: 400 } }
       f.has_many :tagged_items, allow_destroy: true, new_record: true, heading: 'Tags' do |a|
@@ -113,7 +116,9 @@ ActiveAdmin.register News do
       row :author
       row :published
       row :is_featured
-      row :position
+      row :position do
+        ActiveAdminHelper.position(ad.featured_position)
+      end
       row :summary
       row :tags do
         ActiveAdminHelper.tags_names(ad.tags)

--- a/app/assets/javascripts/active_admin.js
+++ b/app/assets/javascripts/active_admin.js
@@ -1,1 +1,2 @@
 //= require active_admin/base
+//= require activeadmin-sortable

--- a/app/assets/javascripts/views/shared/cards.js
+++ b/app/assets/javascripts/views/shared/cards.js
@@ -4,7 +4,8 @@
     el: '.js-masonry-cards',
 
     options: {
-      itemSelector: '.js-masonry-item'
+      itemSelector: '.js-masonry-item',
+      horizontalOrder: true
     },
 
     initialize: function () {

--- a/app/controllers/homepage_controller.rb
+++ b/app/controllers/homepage_controller.rb
@@ -10,7 +10,7 @@ class HomepageController < ApplicationController
 
     @tweets = TwitterApi.get_tweets
     @insights = records.flatten.sort do |a, b|
-      [[a[:position] ? 0 : 1, a[:position]], b[:updated_at]] <=> [[b[:position] ? 0 : 1, b[:position]], a[:updated_at]]
+      [[a.featured_position ? 0 : 1, a.featured_position ? a.featured_position.position : nil], b[:updated_at]] <=> [[b.featured_position ? 0 : 1, b.featured_position ? b.featured_position.position : nil], a[:updated_at]]
     end[0..5]
   end
 end

--- a/app/helpers/active_admin_helper.rb
+++ b/app/helpers/active_admin_helper.rb
@@ -3,6 +3,10 @@ module ActiveAdminHelper
 		tags.pluck(:name).join(', ')
   end
 
+  def self.position(featured_position)
+    featured_position.position rescue nil
+  end
+
   def self.format_date(date)
     date.strftime("%B %d, %Y")
   end

--- a/app/models/blog.rb
+++ b/app/models/blog.rb
@@ -31,6 +31,9 @@ class Blog < ApplicationRecord
 
   belongs_to :category, required: true
 
+  has_one :featured_position, as: :positionable, dependent: :destroy
+  accepts_nested_attributes_for :featured_position, allow_destroy: true
+
   has_many :tagged_items, :as => :taggable, :dependent => :destroy
   has_many :tags, :through => :tagged_items
   accepts_nested_attributes_for :tagged_items, allow_destroy: true

--- a/app/models/blog.rb
+++ b/app/models/blog.rb
@@ -33,6 +33,7 @@ class Blog < ApplicationRecord
 
   has_one :featured_position, as: :positionable, dependent: :destroy
   accepts_nested_attributes_for :featured_position, allow_destroy: true
+  validates_presence_of :featured_position, if: :is_featured?, message: "must be present if featured"
 
   has_many :tagged_items, :as => :taggable, :dependent => :destroy
   has_many :tags, :through => :tagged_items

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -30,6 +30,9 @@ class Event < ApplicationRecord
 
   belongs_to :category, required: true
 
+  has_one :featured_position, as: :positionable, dependent: :destroy
+  accepts_nested_attributes_for :featured_position, allow_destroy: true
+
   has_many :tagged_items, :as => :taggable, :dependent => :destroy
   has_many :tags, :through => :tagged_items
   accepts_nested_attributes_for :tagged_items, allow_destroy: true

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -32,6 +32,7 @@ class Event < ApplicationRecord
 
   has_one :featured_position, as: :positionable, dependent: :destroy
   accepts_nested_attributes_for :featured_position, allow_destroy: true
+  validates_presence_of :featured_position, if: :is_featured?, message: "must be present if featured"
 
   has_many :tagged_items, :as => :taggable, :dependent => :destroy
   has_many :tags, :through => :tagged_items

--- a/app/models/featured_position.rb
+++ b/app/models/featured_position.rb
@@ -1,0 +1,16 @@
+# == Schema Information
+#
+# Table name: featured_positions
+#
+#  id                :integer          not null, primary key
+#  position          :integer
+#  positionable_type :string
+#  positionable_id   :integer
+#  created_at        :datetime         not null
+#  updated_at        :datetime         not null
+#
+
+class FeaturedPosition < ApplicationRecord
+  belongs_to :positionable, polymorphic: true
+  validates_uniqueness_of :position
+end

--- a/app/models/featured_position.rb
+++ b/app/models/featured_position.rb
@@ -11,6 +11,8 @@
 #
 
 class FeaturedPosition < ApplicationRecord
+  acts_as_list
+
   belongs_to :positionable, polymorphic: true
   validates_uniqueness_of :position
 end

--- a/app/models/library.rb
+++ b/app/models/library.rb
@@ -31,6 +31,9 @@ class Library < ApplicationRecord
 
   belongs_to :category, required: true
 
+  has_one :featured_position, as: :positionable, dependent: :destroy
+  accepts_nested_attributes_for :featured_position, allow_destroy: true
+
   has_attached_file :image, styles: {thumb: '300x300>'}
   has_many :tagged_items, :as => :taggable, :dependent => :destroy
   has_many :tags, :through => :tagged_items

--- a/app/models/library.rb
+++ b/app/models/library.rb
@@ -33,6 +33,7 @@ class Library < ApplicationRecord
 
   has_one :featured_position, as: :positionable, dependent: :destroy
   accepts_nested_attributes_for :featured_position, allow_destroy: true
+  validates_presence_of :featured_position, if: :is_featured?, message: "must be present if featured"
 
   has_attached_file :image, styles: {thumb: '300x300>'}
   has_many :tagged_items, :as => :taggable, :dependent => :destroy

--- a/app/models/news.rb
+++ b/app/models/news.rb
@@ -32,6 +32,7 @@ class News < ApplicationRecord
 
   has_one :featured_position, as: :positionable, dependent: :destroy
   accepts_nested_attributes_for :featured_position, allow_destroy: true
+  validates_presence_of :featured_position, if: :is_featured?, message: "must be present if featured"
 
   has_many :tagged_items, :as => :taggable, :dependent => :destroy
   has_many :tags, :through => :tagged_items

--- a/app/models/news.rb
+++ b/app/models/news.rb
@@ -30,6 +30,9 @@ class News < ApplicationRecord
 
   belongs_to :category, required: true
 
+  has_one :featured_position, as: :positionable, dependent: :destroy
+  accepts_nested_attributes_for :featured_position, allow_destroy: true
+
   has_many :tagged_items, :as => :taggable, :dependent => :destroy
   has_many :tags, :through => :tagged_items
   accepts_nested_attributes_for :tagged_items, allow_destroy: true

--- a/db/migrate/20171205101211_create_featured_positions.rb
+++ b/db/migrate/20171205101211_create_featured_positions.rb
@@ -1,0 +1,10 @@
+class CreateFeaturedPositions < ActiveRecord::Migration[5.0]
+  def change
+    create_table :featured_positions do |t|
+      t.integer :position
+      t.references :positionable, polymorphic: true, index: { name: "index_featured_positions_on_positionable" }
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171116143604) do
+ActiveRecord::Schema.define(version: 20171205101211) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -158,6 +158,15 @@ ActiveRecord::Schema.define(version: 20171116143604) do
     t.string   "record_type",        default: "event"
     t.boolean  "is_featured",        default: false
     t.integer  "position"
+  end
+
+  create_table "featured_positions", force: :cascade do |t|
+    t.integer  "position"
+    t.string   "positionable_type"
+    t.integer  "positionable_id"
+    t.datetime "created_at",        null: false
+    t.datetime "updated_at",        null: false
+    t.index ["positionable_type", "positionable_id"], name: "index_featured_positions_on_positionable", using: :btree
   end
 
   create_table "friendly_id_slugs", force: :cascade do |t|


### PR DESCRIPTION
Make a separate admin tab to sort the featured posts that show up on the homepage.

This PR doesn't remove the old position field from the records, so this way we can copy the old order to the new field and then remove it.

[Pivotal task](https://www.pivotaltracker.com/story/show/153550246)