### PR TITLE
Fix search filter tags rendering

### DIFF
--- a/app/assets/javascripts/pages/static_pages/search/filter-modal.js
+++ b/app/assets/javascripts/pages/static_pages/search/filter-modal.js
@@ -11,8 +11,8 @@
             footer: '<button class="c-button -white -outline -medium js-cancel">Cancel</button><button type="submit" class="c-button -white -medium js-done">Done</button>',
             // Callback executed when the user presses the "Done" button
             // The callback gets passed the name of the selected chart,
-            tags: gon.tags || [],
             isForm: true,
+            tags: [],
             form: {
                 action: '/search',
                 id: 'tag-filters',
@@ -60,7 +60,7 @@
     
         render: function () {
             this.options.content = this.contentTemplate({
-                tags: this.options.tags,
+                tags: gon.tags || [],
                 selectedTags: this.options.selectedTags,
                 footer: this.options.footer
             });


### PR DESCRIPTION
*Bug:* When clicking tag, from the resulting search page, the filter tags modal does not display the tags on first load:

![image](https://user-images.githubusercontent.com/8505382/34614331-5a5071b8-f231-11e7-8b87-bc2d140ec152.png)
