### PR TITLE
Delete data from carto when unpublishing dataset

### DIFF
--- a/app/admin/dataset.rb
+++ b/app/admin/dataset.rb
@@ -111,7 +111,6 @@ ActiveAdmin.register Dataset do
       f.input :country, as: :select, collection: Country.all, include_blank: false
       f.input :category, as: :select, collection: Dataset.categories.map {|name, _| [name.humanize, name] }, include_blank: false
       f.input :status, as: :select, collection: Dataset.statuses.map {|name, _| [name.humanize, name] }, include_blank: false
-      f.input :user, as: :select, collection: User.all.map {|u| [u.name_or_email, u.id]}, include_blank: false
       f.input :file, as: :hidden, input_html: { value: f.object.cached_file_data }
       f.input :file, as: :file, hint: f.object.file.present? ? content_tag(:span, f.object.file.original_filename) : content_tag(:span, 'No file yet')
       

--- a/app/controllers/datasets_controller.rb
+++ b/app/controllers/datasets_controller.rb
@@ -39,7 +39,9 @@ class DatasetsController < ApplicationController
   
   def update
     dataset = Dataset.find(params[:id])
-    dataset.update(dataset_params)
+    unless dataset.published?
+      dataset.update(dataset_params)
+    end
     
     render json: dataset, methods: %i(file_absolute_url csv_errors is_valid_for_preview csv_is_valid)
   end

--- a/app/javascript/components/datasets/dataset/component.js
+++ b/app/javascript/components/datasets/dataset/component.js
@@ -2,6 +2,8 @@ import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
 
+import './styles.scss';
+
 class Dataset extends PureComponent {
   static propTypes = {
     dataset: PropTypes.shape({
@@ -30,6 +32,7 @@ class Dataset extends PureComponent {
 
   render() {
     const showPublishButton = this.props.dataset.status === 'unpublished' && this.props.dataset.csv_is_valid;
+    const isEditDisabled = this.props.dataset.status === 'published';
     const { currentLayer, dataset } = this.props;
     const isEnabled = currentLayer && currentLayer.id.toString() === dataset.id.toString();
 
@@ -58,6 +61,7 @@ class Dataset extends PureComponent {
           <button
             className="action-button"
             onClick={this.handleEdit}
+            disabled={isEditDisabled}
           >
             Edit
           </button>

--- a/app/javascript/components/datasets/dataset/styles.scss
+++ b/app/javascript/components/datasets/dataset/styles.scss
@@ -1,0 +1,10 @@
+.action-button {
+  &:disabled {
+    opacity: .7;
+    pointer-events: auto;
+
+    &:hover {
+      cursor: not-allowed;
+    }
+  }
+}

--- a/app/javascript/components/datasets/sidebar/styles.scss
+++ b/app/javascript/components/datasets/sidebar/styles.scss
@@ -177,6 +177,15 @@
               background-color: #2F939C;
               color: #fff;
             }
+
+            &:disabled {
+              opacity: .7;
+              pointer-events: auto;
+
+              &:hover {
+                cursor: not-allowed;
+              }
+            }
           }
         }
       }

--- a/app/services/delete_dataset_from_carto.rb
+++ b/app/services/delete_dataset_from_carto.rb
@@ -3,7 +3,7 @@ class DeleteDatasetFromCarto
   CARTODB_API_KEY = ENV['FSP_CARTO_UPLOAD_API_KEY']
   CARTODB_TABLE = ENV['FSP_CARTO_TABLE']
   
-  attr_reader :dataset, :message
+  attr_reader :dataset, :message, :error
   
   def initialize(dataset_id)
     @dataset = Dataset.find(dataset_id)
@@ -13,6 +13,7 @@ class DeleteDatasetFromCarto
     resp = HTTParty.post(api_url_with_key, body: { "q": delete_query })
     
     if resp["error"].present?
+      @error = resp['error']
       @message = "Dataset was not deleted. Error message: #{resp['error']}."
       false
     else


### PR DESCRIPTION
– Remove dataset from carto if its status changes
– Remove user input from dataset form in ActiveAdmin
– Disable dataset edit button if it is published