### PR TITLE
search by country and regions for library

### DIFF
--- a/app/models/blog.rb
+++ b/app/models/blog.rb
@@ -63,16 +63,20 @@ class Blog < ApplicationRecord
   scope :search_fields, ->(term) do
     where(published: true)
       .joins(:category)
-      .where("lower(blogs.title) LIKE ? OR lower(summary) LIKE ? OR lower(content) LIKE ? OR lower(categories.name) LIKE ?",
-             "%#{term.downcase}%", "%#{term.downcase}%", "%#{term.downcase}%", "%#{term.downcase}%")
+      .joins(:countries)
+      .joins(:regions)
+      .where("lower(blogs.title) LIKE ? OR lower(summary) LIKE ? OR lower(content) LIKE ? OR lower(categories.name) LIKE ? OR lower(countries.name) LIKE ? OR lower(regions.name) LIKE ?",
+             "%#{term.downcase}%", "%#{term.downcase}%", "%#{term.downcase}%", "%#{term.downcase}%", "%#{term.downcase}%", "%#{term.downcase}%")
       .distinct
   end
 
   scope :search_tags, ->(term) do
     where(published: true)
-     .joins(:tags)
-     .where("lower(tags.slug) LIKE ?", "%#{term.downcase}%")
-     .distinct
+      .joins(:tags)
+      .joins(:countries)
+      .joins(:regions)
+      .where("lower(tags.slug) LIKE ? OR lower(countries.iso) LIKE ? OR lower(regions.iso) LIKE ?", "%#{term.downcase}%", "%#{term.downcase}%", "%#{term.downcase}%")
+      .distinct
    end
 
   def set_date

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -66,16 +66,20 @@ class Event < ApplicationRecord
   scope :search_fields, ->(term) do
     where(published: true)
       .joins(:category)
-      .where("lower(events.title) LIKE ? OR lower(summary) LIKE ? OR lower(content) LIKE ? OR lower(categories.name) LIKE ?",
-             "%#{term.downcase}%", "%#{term.downcase}%", "%#{term.downcase}%", "%#{term.downcase}%")
+      .joins(:countries)
+      .joins(:regions)
+      .where("lower(events.title) LIKE ? OR lower(summary) LIKE ? OR lower(content) LIKE ? OR lower(categories.name) LIKE ? OR lower(countries.name) LIKE ? OR lower(regions.name) LIKE ?",
+             "%#{term.downcase}%", "%#{term.downcase}%", "%#{term.downcase}%", "%#{term.downcase}%", "%#{term.downcase}%", "%#{term.downcase}%")
       .distinct
   end
 
   scope :search_tags, ->(term) do
     where(published: true)
-     .joins(:tags)
-     .where("lower(tags.slug) LIKE ?", "%#{term.downcase}%")
-     .distinct
+      .joins(:tags)
+      .joins(:countries)
+      .joins(:regions)
+      .where("lower(tags.slug) LIKE ? OR lower(countries.iso) LIKE ? OR lower(regions.iso) LIKE ?", "%#{term.downcase}%", "%#{term.downcase}%", "%#{term.downcase}%")
+      .distinct
    end
 
   def set_date

--- a/app/models/library.rb
+++ b/app/models/library.rb
@@ -68,17 +68,21 @@ class Library < ApplicationRecord
 
   scope :search_fields, ->(term) do
     where(published: true)
-     .joins(:category)
-     .where("lower(libraries.title) LIKE ? OR lower(summary) LIKE ? OR lower(categories.name) LIKE ?",
-            "%#{term.downcase}%", "%#{term.downcase}%", "%#{term.downcase}%")
-     .distinct
+      .joins(:category)
+      .joins(:countries)
+      .joins(:regions)
+      .where("lower(libraries.title) LIKE ? OR lower(summary) LIKE ? OR lower(categories.name) LIKE ? OR lower(countries.name) LIKE ? OR lower(regions.name) LIKE ?",
+             "%#{term.downcase}%", "%#{term.downcase}%", "%#{term.downcase}%", "%#{term.downcase}%", "%#{term.downcase}%")
+      .distinct
    end
 
    scope :search_tags, ->(term) do
     where(published: true)
-     .joins(:tags)
-     .where("lower(tags.slug) LIKE ?", "%#{term.downcase}%")
-     .distinct
+      .joins(:tags)
+      .joins(:countries)
+      .joins(:regions)
+      .where("lower(tags.slug) LIKE ? OR lower(countries.iso) LIKE ? OR lower(regions.iso) LIKE ?", "%#{term.downcase}%", "%#{term.downcase}%", "%#{term.downcase}%")
+      .distinct
    end
 
   def set_date

--- a/app/models/news.rb
+++ b/app/models/news.rb
@@ -61,16 +61,20 @@ class News < ApplicationRecord
   scope :search_fields, ->(term) do
     where(published: true)
       .joins(:category)
-      .where("lower(news.title) LIKE ? OR lower(summary) LIKE ? OR lower(content) LIKE ? OR lower(categories.name) LIKE ?",
-             "%#{term.downcase}%", "%#{term.downcase}%", "%#{term.downcase}%", "%#{term.downcase}%")
+      .joins(:countries)
+      .joins(:regions)
+      .where("lower(news.title) LIKE ? OR lower(summary) LIKE ? OR lower(content) LIKE ? OR lower(categories.name) LIKE ? OR lower(countries.name) LIKE ? OR lower(regions.name) LIKE ?",
+             "%#{term.downcase}%", "%#{term.downcase}%", "%#{term.downcase}%", "%#{term.downcase}%", "%#{term.downcase}%", "%#{term.downcase}%")
       .distinct
   end
 
   scope :search_tags, ->(term) do
     where(published: true)
-     .joins(:tags)
-     .where("lower(tags.slug) LIKE ?", "%#{term.downcase}%")
-     .distinct
+      .joins(:tags)
+      .joins(:countries)
+      .joins(:regions)
+      .where("lower(tags.slug) LIKE ? OR lower(countries.iso) LIKE ? OR lower(regions.iso) LIKE ?", "%#{term.downcase}%", "%#{term.downcase}%", "%#{term.downcase}%")
+      .distinct
    end
 
   def set_date


### PR DESCRIPTION
Added support to search by country name, region name, country iso and region iso.

## Testing instructions

First, you need to assign a country or region to a new, library, event or blog entity.
Then you can search by that country name assigned.
You should see that entity in the search result.

## Pivotal task

[#168506853](https://www.pivotaltracker.com/story/show/168506853)
