### PR TITLE
map width fixed

### DIFF
--- a/app/javascript/components/map/index.js
+++ b/app/javascript/components/map/index.js
@@ -14,12 +14,12 @@ export { actions, reducers, initialState };
 
 export default connect(
   state => ({
-    ...state.fspMaps.sidebar,
     ...state.fspMaps.common,
     ...state.fspMaps.map,
     nearby: state.fspMaps.analysis.nearby,
     areaOfInterest: state.fspMaps.analysis.areaOfInterest,
     jurisdiction: state.fspMaps.analysis.jurisdiction,
+    open: state.fspMaps.analysis.active,
     activeLayers: getActiveLayers(state)
   }),
   actions


### PR DESCRIPTION
⚠️ Before submitting the PR, make sure:

- You are including only one feature
- Commits messages are clear
- You updated the changelog - _small fix corresponding to another PR_
- You asked someone to review it

---

Fix: max width should depend on analysis not on sidebar.

## Testing instructions

data-portal / geospatial data / click on any flag

http://localhost:3000/data-portal/IND/fsp-maps?lat=-1.5818302639606454&layers=%5B%7B%22id%22%3A%22Day%20old%20chick%20hatcheries%22%2C%22opacity%22%3A1%2C%22visibility%22%3Atrue%2C%22visualizationType%22%3A%22normal%22%7D%5D&lng=92.90039062500001&zoom=3

select layer, open analysis, create an area

## Pivotal Tracker
 ------ missing  -.-

