### PR TITLE
added text User and Search for the login and search icons on the header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - Styles for bullet on article text list
 - Possibility of collapse sidebar in map removed
 - Button for National Surveys added in sidebar
+- User icon on the header now have a explicit text
 
 ### Fixed
 

--- a/app/assets/stylesheets/components/shared/c-nav.scss
+++ b/app/assets/stylesheets/components/shared/c-nav.scss
@@ -64,6 +64,18 @@
         }
       }
 
+      &.-with-icon {
+        > a {
+          display: flex;
+          align-items: center;
+
+          > span {
+            display: inline-block;
+            margin-left: 5px;
+          }
+        }
+      }
+
       &.-with-dropdown {
         position: relative;
         transition-duration: 0.5s;

--- a/app/assets/stylesheets/components/shared/c-search.scss
+++ b/app/assets/stylesheets/components/shared/c-search.scss
@@ -124,5 +124,18 @@
     &:focus {
       outline: 0;
     }
+
+    &::-webkit-input-placeholder { /* Chrome/Opera/Safari */
+      color: $color-4;
+    }
+    &::-moz-placeholder { /* Firefox 19+ */
+      color: $color-4;
+    }
+    &:-ms-input-placeholder { /* IE 10+ */
+      color: $color-4;
+    }
+    &:-moz-placeholder { /* Firefox 18- */
+      color: $color-4;
+    }
   }
 }

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -51,16 +51,17 @@
             <% end %>
           </li>
         <% else %>
-          <li class="nav-item <% if devise_controller? %> -current<% end%>">
+          <li class="nav-item <% if devise_controller? %> -current<% end%> -with-icon">
             <%= link_to(new_user_session_path, data: { turbolinks: false }) do %>
               <%= inline_svg('logos/user.svg', class: "icon-login icon #{('-active') if devise_controller? }") %>
+              <span>User</span>
             <% end %>
           </li>
 
           <li class="nav-item -close<% if current_page?(search_path) %> -current -icon<% end%>">
             <%= form_tag(search_path, method: 'get', class: 'c-form-search-inline') do %>
               <svg class="icon icon-search"><use xlink:href="#icon-search"></use></svg>
-              <%= text_field_tag :term %>              
+              <%= text_field_tag :term, nil, placeholder: 'Search' %>
             <% end %>
           </li>
         <% end %>


### PR DESCRIPTION
Added search and user text for the login and search icons.

## How to test

Just check there should be a text for login and search icons on the header.

![Screenshot-header](https://user-images.githubusercontent.com/674179/67383992-8d865e80-f590-11e9-80af-8e4bef7ac28a.PNG)

## Pivotal Tracker

[#168290899](https://www.pivotaltracker.com/story/show/168290899)
