### PR TITLE
Iniatives becomes Research themes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 - Possibility of collapse sidebar in map removed
 - Button for National Surveys added in sidebar
 - User icon on the header now have a explicit text
+- Iniatives becomes to Research themes
 
 ### Fixed
 

--- a/app/views/initiatives/filter_index.html.erb
+++ b/app/views/initiatives/filter_index.html.erb
@@ -1,4 +1,4 @@
-<% title 'Initiatives | i2i' %>
+<% title 'Research themes | i2i' %>
 
 <div class="l-initiatives l-library">
   <div class="l-intro js-hero">
@@ -18,7 +18,7 @@
           <div class="row">
             <div class="c-hero">
               <div class="grid-s-12 grid-l-10">
-                <%= link_to 'Go to i2i initiatives', initiatives_path, class: "initiatives-link" %>
+                <%= link_to 'Go to i2i research themes', initiatives_path, class: "initiatives-link" %>
                 <h1 class="title -highlight -huge"><%= @tag.title %></h1>
               </div>
               <div class="grid-l-6">

--- a/app/views/initiatives/index.html.erb
+++ b/app/views/initiatives/index.html.erb
@@ -1,4 +1,4 @@
-<% title 'Initiatives | i2i' %>
+<% title 'Research themes | i2i' %>
 
 <div class="l-library">
   <div class="l-intro js-hero">
@@ -18,7 +18,7 @@
           <div class="row">
             <div class="c-hero">
               <div class="grid-l-8">
-                <h1 class="title -highlight -huge">i2i initiatives</h1>
+                <h1 class="title -highlight -huge">Research themes</h1>
                 <p class="subtitle">See how we’re working to promote financial inclusion through data-driven insights.</p>
                 </div>
               </div>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -19,7 +19,7 @@
           <%= link_to 'Insights', insights_path, data: { turbolinks: false } %>
         </li>
         <li class="nav-item <% if current_page?(initiatives_path) || controller.controller_name == 'initiatives' %> -current <% end%>">
-          <%= link_to 'Initiatives', initiatives_path, data: { turbolinks: false } %>
+          <%= link_to 'Research themes', initiatives_path, data: { turbolinks: false } %>
         </li>
         <li class="nav-item <% if current_page?(tools_path) %> -current <% end%>">
           <%= link_to 'Tools', tools_path, data: { turbolinks: false } %>

--- a/app/views/shared/_mobile-menu.html.erb
+++ b/app/views/shared/_mobile-menu.html.erb
@@ -13,7 +13,7 @@
             <%= link_to 'Insights', insights_path %>
           </li>
           <li class="nav-item <% if current_page?(initiatives_path) %> -current <% end%>">
-            <%= link_to 'Initiatives', initiatives_path %>
+            <%= link_to 'Research themes', initiatives_path %>
           </li>
           <li class="nav-item <% if current_page?(tools_path) %> -current <% end%>">
             <%= link_to 'Tools', tools_path %>


### PR DESCRIPTION
Changed "Initiatives" to "Research themes"

## Testing instructions

Ensure Initiatives has been changed to Research themes in the header, the title of the section and links in the breadcrumbs.

## Pivotal Tracker

[#169448816](https://www.pivotaltracker.com/story/show/169448816)
