### PR TITLE
cards on gray color and smaller

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
 - User icon on the header now have a explicit text
 - Iniatives becomes to Research themes
 - Changed contact form in order to send messages from server instead Salesforce
+- Changed color and size for tags inside cards for insights
 
 ### Fixed
 

--- a/app/assets/stylesheets/components/shared/c-card.scss
+++ b/app/assets/stylesheets/components/shared/c-card.scss
@@ -45,18 +45,18 @@
   }
 
   .tags-container {
-    color: $color-1;
+    color: rgba(0, 29, 34, 0.3);
     font-family: $font-family-2;
-    font-size: $font-size-s;
+    font-size: 13px;
     font-weight: bold;
     line-height: 1.75;
     margin-top: 20px;
   }
 
   .tag {
-    color: $color-1;
+    color: rgba(0, 29, 34, 0.3);
     font-family: $font-family-2;
-    font-size: $font-size-s;
+    font-size: 13px;
     font-weight: bold;
     text-decoration: underline;
   }
@@ -82,7 +82,7 @@
           text-align: center;
           width: 100%;
 
-          &:hover {          
+          &:hover {
             color: $color-4;
             background-color: $color-1;
           }
@@ -104,7 +104,7 @@
 
       font-size: $font-size-small;
       font-weight: $font-weight-bold;
-      color: $color-1; 
+      color: $color-1;
     }
   }
 


### PR DESCRIPTION
Changed color and size for tags inside cards for insights

## Testing instructions

Browse to the insights page and check the tags should have a gray color and should be smaller than before.

## Pivotal Tracker

[#169482797]https://www.pivotaltracker.com/story/show/169482797()
