### PR TITLE
migrated contact form to simple form

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -31,6 +31,8 @@ gem 'webpacker'
 gem 'react-rails'
 # Reduces boot times through caching; required in config/boot.rb
 gem 'bootsnap', '>= 1.1.0', require: false
+gem 'simple_form'
+gem 'recaptcha'
 
 # CORS
 gem 'rack-cors'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -198,6 +198,7 @@ GEM
       rails-dom-testing (>= 1, < 3)
       railties (>= 4.2.0)
       thor (>= 0.14, < 2.0)
+    json (2.2.0)
     jsonapi-renderer (0.2.0)
     kaminari (1.1.1)
       activesupport (>= 4.1.0)
@@ -328,6 +329,8 @@ GEM
       execjs
       railties (>= 3.2)
       tilt
+    recaptcha (5.2.1)
+      json
     redis (4.1.0)
     redis-actionpack (5.0.2)
       actionpack (>= 4.0, < 6)
@@ -366,6 +369,9 @@ GEM
     shrine (2.16.0)
       content_disposition (~> 1.0)
       down (~> 4.1)
+    simple_form (5.0.1)
+      actionpack (>= 5.0)
+      activemodel (>= 5.0)
     simple_oauth (0.3.1)
     sparkpost_rails (1.5.1)
       rails (>= 4.0, < 5.3)
@@ -481,9 +487,11 @@ DEPENDENCIES
   rails-assets-vega (~> 2.6.5)!
   rails-backbone (~> 1.2)
   react-rails
+  recaptcha
   redis-rails
   sass-rails (~> 5.0)
   shrine (~> 2.0)
+  simple_form
   sparkpost_rails
   spring
   spring-watcher-listen (~> 2.0.0)

--- a/app/assets/stylesheets/components/shared/c-form.scss
+++ b/app/assets/stylesheets/components/shared/c-form.scss
@@ -74,4 +74,15 @@
   textarea {
     resize: none;
   }
+
+  .actions {
+    .g-recaptcha {
+      margin-top: 30px;
+    }
+
+    input[type="submit"],
+    button[type="submit"] {
+      margin-top: 30px;
+    }
+  }
 }

--- a/app/controllers/static_pages_controller.rb
+++ b/app/controllers/static_pages_controller.rb
@@ -1,6 +1,7 @@
 class StaticPagesController < ApplicationController
 
   def about
+    @contact = Contact.new
     @teamMembers = sort_by_importance(Member.where(role: 1))
     @advisoryMembers = sort_by_importance(Member.where(role: 2))
     @countries = [
@@ -23,21 +24,6 @@ class StaticPagesController < ApplicationController
     gon.advisor = JSON.parse @advisoryMembers.to_json(:methods => [:image_url])
   end
 
-  def email
-    email = params.require(:email).permit(:name, :email, :subject)
-    if valid_email_contact? email
-      begin
-        ContactMailer.message_mail(email.to_h).deliver!
-      rescue SparkPostRails::DeliveryException => e
-        Rails.logger.error "Error sending the email: #{e}"
-      end
-
-      render json: email.to_json, status: :created
-    else
-      render json: email.errors, status: :unprocessable_entity
-    end
-  end
-
   def terms_of_use; end
 
   def privacy_policy; end
@@ -50,10 +36,5 @@ class StaticPagesController < ApplicationController
 
   def sort_by_importance(members)
     members.sort_by { |member| [member.order ? 0 : 1, member.order] }
-  end
-
-  def valid_email_contact?(email)
-    return false unless email.key?(:name) && email.key?(:email) && email.key?(:subject)
-    !email[:name].blank? && !email[:email].blank? && !email[:subject].blank?
   end
 end

--- a/app/mailers/contact_mailer.rb
+++ b/app/mailers/contact_mailer.rb
@@ -32,6 +32,7 @@ class ContactMailer < ApplicationMailer
   end
 
   def message_mail(message)
+    puts message
     @contact = message
     data = { template_id: 'message', substitution_data: message }
     mail(to: ENV.fetch('I2I_MAIL'), sparkpost_data: data)

--- a/app/models/contact.rb
+++ b/app/models/contact.rb
@@ -11,8 +11,8 @@
 #
 
 class Contact < ApplicationRecord
-  validates_presence_of :email
-  validates_format_of :email, with: Devise.email_regexp
+  #validates_presence_of :email
+  validates :email, format: { with: Devise.email_regexp, message: 'Invalid email format' }
 
   # validates :country, inclusion: { in: Country.pluck(:iso) | Region.pluck(:iso) }
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -38,8 +38,8 @@
   </head>
   <body>
     <%= render partial: 'shared/icons' %>
-    <%= render partial: 'shared/alerts' %>
     <%= render partial: 'shared/mobile-menu' %>
+    <%= render partial: 'shared/alerts' %>
     <%= yield %>
     <%= render partial: 'shared/footer' %>
     <%= render partial: 'shared/analytics' if Rails.env.production? %>

--- a/app/views/static_pages/_contact_form_messages.js.erb
+++ b/app/views/static_pages/_contact_form_messages.js.erb
@@ -8,7 +8,7 @@ if (errors) {
   });
   $messages
     .addClass('message').addClass('-alert')
-    .append('<ul></ul>').find('ul').html(errors_html);
+    .html('<ul></ul>').find('ul').html(errors_html);
 }
 
 else if (success) {

--- a/app/views/static_pages/_contact_form_messages.js.erb
+++ b/app/views/static_pages/_contact_form_messages.js.erb
@@ -1,0 +1,19 @@
+var errors = JSON.parse('<%= defined?(errors) ? errors.to_json.html_safe : nil %>');
+var $messages = $("#messages");
+
+if (errors) {
+  $messages.addClass('-info');
+  var errors_html = errors.base.map(function(e) {
+    return $('<li></li>').html(e);
+  });
+  $messages
+    .addClass('message').addClass('-alert')
+    .append('<ul></ul>').find('ul').html(errors_html);
+}
+
+else if (success) {
+  $messages
+    .addClass('message').addClass('-info')
+    .html('Thanks! Your message has been sent.');
+  $('.custom-row').hide();
+}

--- a/app/views/static_pages/about.html.erb
+++ b/app/views/static_pages/about.html.erb
@@ -272,44 +272,20 @@
           <div class="grid-s-12">
             <div class="l-form-contact">
               <div class="grid-s-12 grid-m-8">
-                <%= form_with(model: @contact, url: about_contacts_path, remote: false, class: 'c-form contact-form') do |f| %>
-                  <input type=hidden name='captcha_settings' value='{"keyname":"GoogleCAPTCHA","fallback":"true","orgId":"00D0Y000002FWyG","ts":""}'>
-                  <input type=hidden name="orgid" value="00D0Y000002FWyG">
-                  <input type=hidden name="retURL" value="https://i2ifacility.org/about">
 
-                  <div class="custom-row">
-                    <%= f.label :first_name %>
-                    <%= f.text_field :first_name, max: 40, size: 20, required: true %>
-                  </div>
-                  <div class="custom-row">
-                    <%= f.label :last_name %>
-                    <%= f.text_field :last_name, max: 80, size: 20 %>
-                  </div>
-                  <div class="custom-row">
-                    <%= f.label :email %>
-                    <%= f.email_field :email, max: 80, size: 20, required: true %>
-                  </div>
-                  <div class="custom-row">
-                    <%= f.label :title %>
-                    <%= f.text_field :title, max: 40, size: 20 %>
-                  </div>
-                  <div class="custom-row">
-                    <%= f.label :company %>
-                    <%= f.text_field :company, max: 40, size: 20 %>
-                  </div>
-                  <div class="custom-row">
-                    <%= f.label :country %>
-                    <%= f.text_field :country, max: 40, size: 20 %>
-                  </div>
-                  <div class="custom-row">
-                    <%= f.label :message %>
-                    <%= f.text_area :message, wrap: 'soft', required: true %>
-                  </div>
-
-                  <div style="margin-top: 30px" class="g-recaptcha" data-sitekey="6LfxMawUAAAAABpwWctOmKpQ1XOSW0T-g1__xSry"></div><br>
-
+                <%= simple_form_for @contact, url: about_form_contacts_path, html: { class: 'c-form contact-form' }, defaults: { wrapper_html: { class: 'custom-row' } }, remote: true do |f| %>
+                  <div id="messages"></div>
+                  <%= f.error :base %>
+                  <%= f.input :first_name, required: true %>
+                  <%= f.input :last_name, required: true %>
+                  <%= f.input :email, required: true %>
+                  <%= f.input :title %>
+                  <%= f.input :company %>
+                  <%= f.input :country, as: :string %>
+                  <%= f.input :message, required: true %>
                   <div class="actions">
-                    <%= f.submit "Send", class: 'primary-btn' %>
+                    <%= recaptcha_tags %>
+                    <%= f.button :submit, 'Send', class: 'primary-btn' %>
                   </div>
                 <% end %>
               </div>

--- a/config/initializers/simple_form.rb
+++ b/config/initializers/simple_form.rb
@@ -1,0 +1,176 @@
+# frozen_string_literal: true
+#
+# Uncomment this and change the path if necessary to include your own
+# components.
+# See https://github.com/plataformatec/simple_form#custom-components to know
+# more about custom components.
+# Dir[Rails.root.join('lib/components/**/*.rb')].each { |f| require f }
+#
+# Use this setup block to configure all options available in SimpleForm.
+SimpleForm.setup do |config|
+  # Wrappers are used by the form builder to generate a
+  # complete input. You can remove any component from the
+  # wrapper, change the order or even add your own to the
+  # stack. The options given below are used to wrap the
+  # whole input.
+  config.wrappers :default, class: :input,
+    hint_class: :field_with_hint, error_class: :field_with_errors, valid_class: :field_without_errors do |b|
+    ## Extensions enabled by default
+    # Any of these extensions can be disabled for a
+    # given input by passing: `f.input EXTENSION_NAME => false`.
+    # You can make any of these extensions optional by
+    # renaming `b.use` to `b.optional`.
+
+    # Determines whether to use HTML5 (:email, :url, ...)
+    # and required attributes
+    b.use :html5
+
+    # Calculates placeholders automatically from I18n
+    # You can also pass a string as f.input placeholder: "Placeholder"
+    b.use :placeholder
+
+    ## Optional extensions
+    # They are disabled unless you pass `f.input EXTENSION_NAME => true`
+    # to the input. If so, they will retrieve the values from the model
+    # if any exists. If you want to enable any of those
+    # extensions by default, you can change `b.optional` to `b.use`.
+
+    # Calculates maxlength from length validations for string inputs
+    # and/or database column lengths
+    b.optional :maxlength
+
+    # Calculate minlength from length validations for string inputs
+    b.optional :minlength
+
+    # Calculates pattern from format validations for string inputs
+    b.optional :pattern
+
+    # Calculates min and max from length validations for numeric inputs
+    b.optional :min_max
+
+    # Calculates readonly automatically from readonly attributes
+    b.optional :readonly
+
+    ## Inputs
+    # b.use :input, class: 'input', error_class: 'is-invalid', valid_class: 'is-valid'
+    b.use :label_input
+    b.use :hint,  wrap_with: { tag: :span, class: :hint }
+    b.use :error, wrap_with: { tag: :span, class: :error }
+
+    ## full_messages_for
+    # If you want to display the full error message for the attribute, you can
+    # use the component :full_error, like:
+    #
+    # b.use :full_error, wrap_with: { tag: :span, class: :error }
+  end
+
+  # The default wrapper to be used by the FormBuilder.
+  config.default_wrapper = :default
+
+  # Define the way to render check boxes / radio buttons with labels.
+  # Defaults to :nested for bootstrap config.
+  #   inline: input + label
+  #   nested: label > input
+  config.boolean_style = :nested
+
+  # Default class for buttons
+  config.button_class = 'btn'
+
+  # Method used to tidy up errors. Specify any Rails Array method.
+  # :first lists the first message for each field.
+  # Use :to_sentence to list all errors for each field.
+  # config.error_method = :first
+
+  # Default tag used for error notification helper.
+  config.error_notification_tag = :div
+
+  # CSS class to add for error notification helper.
+  config.error_notification_class = 'error_notification'
+
+  # Series of attempts to detect a default label method for collection.
+  # config.collection_label_methods = [ :to_label, :name, :title, :to_s ]
+
+  # Series of attempts to detect a default value method for collection.
+  # config.collection_value_methods = [ :id, :to_s ]
+
+  # You can wrap a collection of radio/check boxes in a pre-defined tag, defaulting to none.
+  # config.collection_wrapper_tag = nil
+
+  # You can define the class to use on all collection wrappers. Defaulting to none.
+  # config.collection_wrapper_class = nil
+
+  # You can wrap each item in a collection of radio/check boxes with a tag,
+  # defaulting to :span.
+  # config.item_wrapper_tag = :span
+
+  # You can define a class to use in all item wrappers. Defaulting to none.
+  # config.item_wrapper_class = nil
+
+  # How the label text should be generated altogether with the required text.
+  # config.label_text = lambda { |label, required, explicit_label| "#{required} #{label}" }
+
+  # You can define the class to use on all labels. Default is nil.
+  # config.label_class = nil
+
+  # You can define the default class to be used on forms. Can be overriden
+  # with `html: { :class }`. Defaulting to none.
+  # config.default_form_class = nil
+
+  # You can define which elements should obtain additional classes
+  # config.generate_additional_classes_for = [:wrapper, :label, :input]
+
+  # Whether attributes are required by default (or not). Default is true.
+  # config.required_by_default = true
+
+  # Tell browsers whether to use the native HTML5 validations (novalidate form option).
+  # These validations are enabled in SimpleForm's internal config but disabled by default
+  # in this configuration, which is recommended due to some quirks from different browsers.
+  # To stop SimpleForm from generating the novalidate option, enabling the HTML5 validations,
+  # change this configuration to true.
+  config.browser_validations = false
+
+  # Custom mappings for input types. This should be a hash containing a regexp
+  # to match as key, and the input type that will be used when the field name
+  # matches the regexp as value.
+  # config.input_mappings = { /count/ => :integer }
+
+  # Custom wrappers for input types. This should be a hash containing an input
+  # type as key and the wrapper that will be used for all inputs with specified type.
+  # config.wrapper_mappings = { string: :prepend }
+
+  # Namespaces where SimpleForm should look for custom input classes that
+  # override default inputs.
+  # config.custom_inputs_namespaces << "CustomInputs"
+
+  # Default priority for time_zone inputs.
+  # config.time_zone_priority = nil
+
+  # Default priority for country inputs.
+  # config.country_priority = nil
+
+  # When false, do not use translations for labels.
+  # config.translate_labels = true
+
+  # Automatically discover new inputs in Rails' autoload path.
+  # config.inputs_discovery = true
+
+  # Cache SimpleForm inputs discovery
+  # config.cache_discovery = !Rails.env.development?
+
+  # Default class for inputs
+  # config.input_class = nil
+
+  # Define the default class of the input wrapper of the boolean input.
+  config.boolean_label_class = 'checkbox'
+
+  # Defines if the default input wrapper class should be included in radio
+  # collection wrappers.
+  # config.include_default_input_wrapper_class = true
+
+  # Defines which i18n scope will be used in Simple Form.
+  # config.i18n_scope = 'simple_form'
+
+  # Defines validation classes to the input_field. By default it's nil.
+  # config.input_field_valid_class = 'is-valid'
+  # config.input_field_error_class = 'is-invalid'
+end

--- a/config/locales/simple_form.en.yml
+++ b/config/locales/simple_form.en.yml
@@ -1,0 +1,31 @@
+en:
+  simple_form:
+    "yes": 'Yes'
+    "no": 'No'
+    required:
+      text: 'required'
+      mark: '*'
+      # You can uncomment the line below if you need to overwrite the whole required html.
+      # When using html, text and mark won't be used.
+      # html: '<abbr title="required">*</abbr>'
+    error_notification:
+      default_message: "Please review the problems below:"
+    # Examples
+    # labels:
+    #   defaults:
+    #     password: 'Password'
+    #   user:
+    #     new:
+    #       email: 'E-mail to sign in.'
+    #     edit:
+    #       email: 'E-mail.'
+    # hints:
+    #   defaults:
+    #     username: 'User name to sign in.'
+    #     password: 'No special characters, please.'
+    # include_blanks:
+    #   defaults:
+    #     age: 'Rather not say'
+    # prompts:
+    #   defaults:
+    #     age: 'Select your age'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -62,7 +62,6 @@ Rails.application.routes.draw do
 
   get 'resources(/:category)', to: 'libraries#index', as: 'libraries'
 
-  post 'email' => 'static_pages#email'
   get 'about' => 'static_pages#about'
   get 'terms-of-use', to: 'static_pages#terms_of_use', as: 'terms_of_use'
   get 'privacy-policy', to: 'static_pages#privacy_policy', as: 'privacy_policy'
@@ -71,7 +70,7 @@ Rails.application.routes.draw do
 
   resource :contacts, only: :create do
     post :batch_download
-    post :about
+    post :about_form
   end
 
   scope :format => true, :constraints => { :format => 'json' } do

--- a/lib/templates/erb/scaffold/_form.html.erb
+++ b/lib/templates/erb/scaffold/_form.html.erb
@@ -1,0 +1,15 @@
+<%# frozen_string_literal: true %>
+<%%= simple_form_for(@<%= singular_table_name %>) do |f| %>
+  <%%= f.error_notification %>
+  <%%= f.error_notification message: f.object.errors[:base].to_sentence if f.object.errors[:base].present? %>
+
+  <div class="form-inputs">
+  <%- attributes.each do |attribute| -%>
+    <%%= f.<%= attribute.reference? ? :association : :input %> :<%= attribute.name %> %>
+  <%- end -%>
+  </div>
+
+  <div class="form-actions">
+    <%%= f.button :submit %>
+  </div>
+<%% end %>


### PR DESCRIPTION
Migrated contact form to simple form gem.

## Testing instructions

Run `bundle install`.

Add new env variables to `.env` file:

```
RECAPTCHA_SITE_KEY=""
RECAPTCHA_SECRET_KEY=""
```
Browse to about page. The contact form is on the bottom. You now should be able to fill, send and see errors or a success message.

## Pivotal Tracker

Link to the task(s), if any
