### PR TITLE
Fix/national surveys download all

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,3 +49,4 @@
 - Fixed an issue where scroll jumps to the top of the page when user clicks on "Show more" button
 - Fixed an issue where contact form message wasn't being sent
 - Fixed an error when user request to download on the national surveys page
+- Fixed an issue where user only received one link instead multiple on download modal

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,3 +48,4 @@
 - Fixed an issue where search by iso doesn't return any result
 - Fixed an issue where scroll jumps to the top of the page when user clicks on "Show more" button
 - Fixed an issue where contact form message wasn't being sent
+- Fixed an error when user request to download on the national surveys page

--- a/app/assets/javascripts/components/data_portal/modals/modal-download-all.js.erb
+++ b/app/assets/javascripts/components/data_portal/modals/modal-download-all.js.erb
@@ -51,13 +51,12 @@
       var self = this;
 
       data = $('form').serializeArray();
-      data.push({ name: 'country', value: this.options.iso });
       data.push({ name: 'email', value: this.emailField.value });
       data.push({ name: 'country', value: this.options.iso });
       data.push({ name: 'year', value: this.options.year });
 
       $.post({
-        url: "<%= contacts_path %>",
+        url: "<%= ns_download_all_contacts_path %>",
         data: data,
         success: function() {
           self.options.content = self.successTemplate({});

--- a/app/controllers/contacts_controller.rb
+++ b/app/controllers/contacts_controller.rb
@@ -18,6 +18,22 @@ class ContactsController < ApplicationController
     end
   end
 
+  def ns_download_all
+    contact = Contact.new(ns_download_all_params)
+
+    if contact.save
+      begin
+        ContactMailer.data_mail(contact).deliver!
+      rescue SparkPostRails::DeliveryException => e
+        Rails.logger.error "Error sending the email: #{e}"
+      end
+
+      render json: contact.to_json, status: :created
+    else
+      render json: contact.errors, status: :unprocessable_entity
+    end
+  end
+
   def about_form
     @contact = Contact.new(contact_params)
 
@@ -67,6 +83,10 @@ class ContactsController < ApplicationController
   end
 
   def batch_download_params
+    params.permit(:email, :country, :terms, links: [])
+  end
+
+  def ns_download_all_params
     params.permit(:email, :country, :terms, links: [])
   end
 end

--- a/app/mailers/contact_mailer.rb
+++ b/app/mailers/contact_mailer.rb
@@ -14,8 +14,12 @@ class ContactMailer < ApplicationMailer
 
   def data_batch_download(contact, links)
     @contact = contact
+    @links_block = ""
 
-    @links_block = "<p><a href=\"#{links[0]}\" target='_blank' download='true'>#{links[0]}</a></p>"
+    links.delete_if { |l| l.include? ".zip" }
+    links.each do |link|
+      @links_block << "<p><a href=\"#{link}\" target='_blank' download='true'>#{link}</a></p>"
+    end
 
     data = {
       template_id: 'country-batch-download',

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -71,6 +71,7 @@ Rails.application.routes.draw do
   resource :contacts, only: :create do
     post :batch_download
     post :about_form
+    post :ns_download_all
   end
 
   scope :format => true, :constraints => { :format => 'json' } do


### PR DESCRIPTION
Fix an error when the user requests to download on the national surveys page.
Fix an issue when the user requests to download files on the data portal page.

## Testing instructions

1. Go to National surveys of any country and click on download at the bottom of the page. You shouldn't see any error and received an email.
2. Go to the Data portal page, select any country and click on Download link. Select more than one and you should receive an email with all links.

## Pivotal Tracker

[#169706059](https://www.pivotaltracker.com/story/show/169706059)
