### PR TITLE
Fix/download btn

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@
 - Widgets restyled and moved from Vega to Recharts 
 - Haiti logo moved in intro
 - Videos section in geospatial portal opened in overlay
+- Download all button in data-portal moved from footer to header
 
 ### Fixed
 

--- a/app/assets/javascripts/pages/data_portal/DataPortalCountryPage.js
+++ b/app/assets/javascripts/pages/data_portal/DataPortalCountryPage.js
@@ -357,6 +357,7 @@
      */
     _renderHeader: function () {
       this.headerContainer.innerHTML = this.headerTemplate({
+        hasDownload: this.countryModel.get('downloadable'),
         error: this._loadingError,
         indicators: this.indicatorsCollection.getVisibleIndicators(),
         filters: this.options._filters
@@ -413,6 +414,7 @@
      */
     _renderMobileHeader: function () {
       this.mobileHeaderContainer.innerHTML = this.mobileHeaderTemplate({
+        hasDownload: this.countryModel.get('downloadable'),
         error: this._loadingError,
         indicators: this.indicatorsCollection.getVisibleIndicators(),
         filters: this.options._filters
@@ -430,7 +432,6 @@
      */
     _renderFooter: function () {
       this.footerContainer.innerHTML = this.footerTemplate({
-        hasDownload: this.countryModel.get('downloadable'),
         error: this._loadingError,
         indicators: this.indicatorsCollection.getVisibleIndicators(),
         mapUrl: this.countryModel.get('url'),

--- a/app/assets/javascripts/pages/data_portal/DataPortalMSMECountryPage.js
+++ b/app/assets/javascripts/pages/data_portal/DataPortalMSMECountryPage.js
@@ -351,6 +351,7 @@
      */
     _renderHeader: function () {
       this.headerContainer.innerHTML = this.headerTemplate({
+        hasDownload: this.countryModel.get('downloadable'),
         error: this._loadingError,
         indicators: this.indicatorsCollection.getVisibleIndicators(),
         filters: this.options._filters
@@ -408,6 +409,7 @@
      */
     _renderMobileHeader: function () {
       this.mobileHeaderContainer.innerHTML = this.mobileHeaderTemplate({
+        hasDownload: this.countryModel.get('downloadable'),
         error: this._loadingError,
         indicators: this.indicatorsCollection.getVisibleIndicators(),
         filters: this.options._filters
@@ -425,7 +427,6 @@
      */
     _renderFooter: function () {
       this.footerContainer.innerHTML = this.footerTemplate({
-        hasDownload: this.countryModel.get('downloadable'),
         error: this._loadingError,
         indicators: this.indicatorsCollection.getVisibleIndicators(),
         mapUrl: this.countryModel.get('url'),

--- a/app/assets/javascripts/pages/data_portal/DataPortalRegionPage.js
+++ b/app/assets/javascripts/pages/data_portal/DataPortalRegionPage.js
@@ -358,6 +358,7 @@
      */
     _renderHeader: function () {
       this.headerContainer.innerHTML = this.headerTemplate({
+        hasDownload: this.countryModel.get('downloadable'),
         error: this._loadingError,
         indicators: this.indicatorsCollection.getVisibleIndicators(),
         filters: this.options._filters
@@ -412,6 +413,7 @@
      */
     _renderMobileHeader: function () {
       this.mobileHeaderContainer.innerHTML = this.mobileHeaderTemplate({
+        hasDownload: this.countryModel.get('downloadable'),
         error: this._loadingError,
         indicators: this.indicatorsCollection.getVisibleIndicators(),
         filters: this.options._filters
@@ -429,7 +431,6 @@
      */
     _renderFooter: function () {
       this.footerContainer.innerHTML = this.footerTemplate({
-        hasDownload: this.countryModel.get('downloadable'),
         error: this._loadingError,
         indicators: this.indicatorsCollection.getVisibleIndicators(),
         mapUrl: this.countryModel.get('url'),

--- a/app/assets/javascripts/templates/data_portal/footer.jst.ejs
+++ b/app/assets/javascripts/templates/data_portal/footer.jst.ejs
@@ -2,9 +2,6 @@
 
   <div class="indicator-options">
       <button class="c-button -white" disabled>Add all to report</button>
-      <% if (hasDownload) { %>
-        <button class="c-button -white js-download-all">Download all</button>
-      <% } %>
       <% if (mapUrl) { %><a class="c-button -white" href="<%= mapUrl %>" rel="noopener" target="_blank">Check FSPmaps data</a><% } %>
     </div>
     <div class="container-custom-indicators">

--- a/app/assets/javascripts/templates/data_portal/header.jst.ejs
+++ b/app/assets/javascripts/templates/data_portal/header.jst.ejs
@@ -43,7 +43,12 @@
           <h1 class="title -highlight -huge js-country"><%= country %></h1>
         </div> -->
         <div class="grid-s-12 grid-m-6 _no-mobile _align-right">
-          <button class="c-button -white js-customize-indicators">Customise indicators</button>
+          <div class="header-buttons">
+              <% if (hasDownload) { %>
+                <button class="c-button -white js-download-all">Download all</button>
+              <% } %>
+            <button class="c-button -white js-customize-indicators">Customise indicators</button>
+          </div>
         </div>
       </div>
     </div>

--- a/app/assets/stylesheets/components/shared/c-header.scss
+++ b/app/assets/stylesheets/components/shared/c-header.scss
@@ -5,6 +5,8 @@
   // margin-top: 10px;
   background: $color-1;
 
+
+
   .container {
     display: flex;
     align-items: center;
@@ -14,6 +16,14 @@
 
     @media #{$mq-laptop} {
       align-items: stretch;
+    }
+
+    > .header-buttons {
+      display: flex;
+      justify-content: flex-end;
+      button:not(:last-child) {
+        margin-right: 20px;
+      }
     }
 
     .hamburguer {

--- a/app/views/data_portal_financial_diaries/_country-selector.html.erb
+++ b/app/views/data_portal_financial_diaries/_country-selector.html.erb
@@ -5,6 +5,7 @@
     <%= link_to 'Go to the ' + @country[:name] + ' data portal', data_portal_country_preview_path(@country[:iso]), :class => 'country-link' %>
   <% end %>
 
+
   <% if current_page?(data_portal_country_preview_path) || current_page?(data_portal_financial_diaries_path) %>
     <%= select_tag "country",
       options_for_select(@countries.collect{ |country| [country[:name], country[:iso]] }.sort, @country[:iso]),


### PR DESCRIPTION
Description of the PR

Download all button moved from the bottom of the page to the header as it was hard for users to find it.

<img width="1191" alt="Screenshot 2019-12-19 at 09 09 44" src="https://user-images.githubusercontent.com/33252015/71156094-8ce01080-223f-11ea-84a7-ea9ed865be7b.png">

## Testing instructions

http://localhost:3000/data-portal/GHA/2010

## Pivotal Tracker

https://www.pivotaltracker.com/story/show/154171770
