### PR TITLE
partners logos width

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,3 +67,4 @@
 - Fixed an issue where contact form message wasn't being sent
 - Fixed an error when user request to download on the national surveys page
 - Fixed an issue where user only received one link instead multiple on download modal
+- Partner's logo displaying weird (width fixed)

--- a/app/assets/stylesheets/layouts/l-data-portal-country.scss
+++ b/app/assets/stylesheets/layouts/l-data-portal-country.scss
@@ -227,7 +227,6 @@
         display: inline-block;
         min-height: 71px;
         max-height: 100px;
-        width: 100%;
 
         &.-width {
           width: 300px;


### PR DESCRIPTION
## Description

Partner logos in data portal displaying weird. 

## Testing instructions

Go to data portal and check logo in different tabs and countries. E.g. :
https://i2ifacility.org/data-portal/BGD/2016

## Pivotal Tracker

https://basecamp.com/1756858/projects/16224488/messages/89402302?enlarge=395634553#attachments_for_message_89402302
https://www.pivotaltracker.com/story/show/170571192
