### PR TITLE
header buttons padding added

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,4 +68,4 @@
 - Fixed an error when user request to download on the national surveys page
 - Fixed an issue where user only received one link instead multiple on download modal
 - Partner's logo displaying weird (width fixed)
-- Data portal header- buttons separated from title
+- Data-portal header - buttons separated from title

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,3 +68,4 @@
 - Fixed an error when user request to download on the national surveys page
 - Fixed an issue where user only received one link instead multiple on download modal
 - Partner's logo displaying weird (width fixed)
+- Data portal header- buttons separated from title

--- a/app/assets/stylesheets/_mixins.scss
+++ b/app/assets/stylesheets/_mixins.scss
@@ -47,6 +47,41 @@
   }
 }
 
+// https://davidwalsh.name/css-triangles
+@mixin triangle($size, $color, $direction) {
+  width: 0;
+  height: 0;
+  font-size: 0;
+	line-height: 0;
+
+  @if($direction == 'up') {
+    border-top: 0;
+    border-left: $size solid transparent;  /* left arrow slant */
+    border-right: $size solid transparent; /* right arrow slant */
+    border-bottom: $size solid $color; /* bottom, add background color here */
+  }
+
+  @if($direction == 'right') {
+    border-right: 0;
+    border-bottom: $size solid transparent;  /* left arrow slant */
+    border-top: $size solid transparent; /* right arrow slant */
+    border-left: $size solid $color; /* bottom, add background color here */
+  }
+
+  @if($direction == 'down') {
+    border-left: $size solid transparent;
+    border-right: $size solid transparent;
+    border-top: $size solid $color;
+  }
+
+  @if($direction == 'left') {
+    border-left: 0;
+    border-bottom: $size solid transparent;  /* left arrow slant */
+	  border-top: $size solid transparent; /* right arrow slant */
+	  border-right: $size solid $color; /* bottom, add background color here */
+  }
+}
+
 @mixin translate_content() {
   padding-top: 50px;
 

--- a/app/assets/stylesheets/exported-components/_mixins.scss
+++ b/app/assets/stylesheets/exported-components/_mixins.scss
@@ -48,3 +48,38 @@
     border-right: 0;
   }
 }
+
+// https://davidwalsh.name/css-triangles
+@mixin triangle($size, $color, $direction) {
+  width: 0;
+  height: 0;
+  font-size: 0;
+	line-height: 0;
+
+  @if($direction == 'up') {
+    border-top: 0;
+    border-left: $size solid transparent;  /* left arrow slant */
+    border-right: $size solid transparent; /* right arrow slant */
+    border-bottom: $size solid $color; /* bottom, add background color here */
+  }
+
+  @if($direction == 'right') {
+    border-right: 0;
+    border-bottom: $size solid transparent;  /* left arrow slant */
+    border-top: $size solid transparent; /* right arrow slant */
+    border-left: $size solid $color; /* bottom, add background color here */
+  }
+
+  @if($direction == 'down') {
+    border-left: $size solid transparent;
+    border-right: $size solid transparent;
+    border-top: $size solid $color;
+  }
+
+  @if($direction == 'left') {
+    border-left: 0;
+    border-bottom: $size solid transparent;  /* left arrow slant */
+	  border-top: $size solid transparent; /* right arrow slant */
+	  border-right: $size solid $color; /* bottom, add background color here */
+  }
+}

--- a/app/assets/stylesheets/layouts/l-data-portal-country.scss
+++ b/app/assets/stylesheets/layouts/l-data-portal-country.scss
@@ -98,6 +98,10 @@
           display: flex;
           align-items: center;
           justify-content: flex-end;
+
+          .header-buttons {
+            padding-top: 20px;
+          }
         }
 
         .c-button {

--- a/app/javascript/components/datasets/sidebar/styles.scss
+++ b/app/javascript/components/datasets/sidebar/styles.scss
@@ -1,39 +1,5 @@
 @import '_settings';
-
-// https://davidwalsh.name/css-triangles
-@mixin triangle($size, $color, $direction) {
-  width: 0;
-  height: 0;
-  font-size: 0;
-	line-height: 0;
-
-  @if($direction == 'up') {
-    border-top: 0;
-    border-left: $size solid transparent;  /* left arrow slant */
-    border-right: $size solid transparent; /* right arrow slant */
-    border-bottom: $size solid $color; /* bottom, add background color here */
-  }
-
-  @if($direction == 'right') {
-    border-right: 0;
-    border-bottom: $size solid transparent;  /* left arrow slant */
-    border-top: $size solid transparent; /* right arrow slant */
-    border-left: $size solid $color; /* bottom, add background color here */
-  }
-
-  @if($direction == 'down') {
-    border-left: $size solid transparent;
-    border-right: $size solid transparent;
-    border-top: $size solid $color;
-  }
-
-  @if($direction == 'left') {
-    border-left: 0;
-    border-bottom: $size solid transparent;  /* left arrow slant */
-	  border-top: $size solid transparent; /* right arrow slant */
-	  border-right: $size solid $color; /* bottom, add background color here */
-  }
-}
+@import '_mixins';
 
 .c-datasets-sidebar {
   z-index: 1;

--- a/app/javascript/components/intro/components/item/styles.scss
+++ b/app/javascript/components/intro/components/item/styles.scss
@@ -1,19 +1,6 @@
 
 @import '_settings';
-
-@mixin arrow($size, $border-width, $color, $direction) {
-  display: inline;
-  width: $size;
-  height: $size;
-  border: $border-width solid $color;
-  content: '';
-
-  @if($direction == 'down') {
-    transform: rotate(45deg);
-    border-top: 0;
-    border-left: 0;
-  }
-}
+@import '_mixins';
 
 .react-select-container {
   display: inline-block;

--- a/app/javascript/components/map/legend/styles.scss
+++ b/app/javascript/components/map/legend/styles.scss
@@ -1,24 +1,5 @@
 @import '_settings';
-
-@mixin triangle($size, $color, $direction) {
-  width: 0;
-  height: 0;
-  font-size: 0;
-	line-height: 0;
-
-  @if($direction == 'up') {
-    border-top: 0;
-    border-left: $size solid transparent;  /* left arrow slant */
-    border-right: $size solid transparent; /* right arrow slant */
-    border-bottom: $size solid $color; /* bottom, add background color here */
-  }
-
-  @if($direction == 'down') {
-    border-left: $size solid transparent;
-    border-right: $size solid transparent;
-    border-top: $size solid $color;
-  }
-}
+@import '_mixins';
 
 .c-legend {
   position: absolute;

--- a/app/javascript/components/sidebar/menu-item/styles.scss
+++ b/app/javascript/components/sidebar/menu-item/styles.scss
@@ -1,38 +1,5 @@
 @import '_settings';
-
-@mixin triangle($size, $color, $direction) {
-  width: 0;
-  height: 0;
-  font-size: 0;
-	line-height: 0;
-
-  @if($direction == 'up') {
-    border-top: 0;
-    border-left: $size solid transparent;  /* left arrow slant */
-    border-right: $size solid transparent; /* right arrow slant */
-    border-bottom: $size solid $color; /* bottom, add background color here */
-  }
-
-  @if($direction == 'right') {
-    border-right: 0;
-    border-bottom: $size solid transparent;  /* left arrow slant */
-    border-top: $size solid transparent; /* right arrow slant */
-    border-left: $size solid $color; /* bottom, add background color here */
-  }
-
-  @if($direction == 'down') {
-    border-left: $size solid transparent;
-    border-right: $size solid transparent;
-    border-top: $size solid $color;
-  }
-
-  @if($direction == 'left') {
-    border-left: 0;
-    border-bottom: $size solid transparent;  /* left arrow slant */
-	  border-top: $size solid transparent; /* right arrow slant */
-	  border-right: $size solid $color; /* bottom, add background color here */
-  }
-}
+@import '_mixins';
 
 .c-menu-item {
   width: 100%;

--- a/app/javascript/components/sidebar/menu-items/styles.scss
+++ b/app/javascript/components/sidebar/menu-items/styles.scss
@@ -1,38 +1,5 @@
 @import '_settings';
-
-@mixin triangle($size, $color, $direction) {
-  width: 0;
-  height: 0;
-  font-size: 0;
-	line-height: 0;
-
-  @if($direction == 'up') {
-    border-top: 0;
-    border-left: $size solid transparent;  /* left arrow slant */
-    border-right: $size solid transparent; /* right arrow slant */
-    border-bottom: $size solid $color; /* bottom, add background color here */
-  }
-
-  @if($direction == 'right') {
-    border-right: 0;
-    border-bottom: $size solid transparent;  /* left arrow slant */
-    border-top: $size solid transparent; /* right arrow slant */
-    border-left: $size solid $color; /* bottom, add background color here */
-  }
-
-  @if($direction == 'down') {
-    border-left: $size solid transparent;
-    border-right: $size solid transparent;
-    border-top: $size solid $color;
-  }
-
-  @if($direction == 'left') {
-    border-left: 0;
-    border-bottom: $size solid transparent;  /* left arrow slant */
-	  border-top: $size solid transparent; /* right arrow slant */
-	  border-right: $size solid $color; /* bottom, add background color here */
-  }
-}
+@import '_mixins';
 
 @font-face {
   font-family: 'Chalet';

--- a/app/javascript/components/sidebar/sectors/styles.scss
+++ b/app/javascript/components/sidebar/sectors/styles.scss
@@ -1,37 +1,5 @@
 @import '_settings';
-
-// https://davidwalsh.name/css-triangles
-@mixin triangle($size, $color, $direction) {
-  width: 0;
-  height: 0;
-  font-size: 0;
-	line-height: 0;
-
-  @if($direction == 'up') {
-    border-top: 0;
-    border-left: $size solid transparent;  /* left arrow slant */
-    border-right: $size solid transparent; /* right arrow slant */
-    border-bottom: $size solid $color; /* bottom, add background color here */
-  }
-
-  @if($direction == 'right') {
-    border-bottom: $size solid transparent;  /* left arrow slant */
-    border-top: $size solid transparent; /* right arrow slant */
-    border-left: $size solid $color; /* bottom, add background color here */
-  }
-
-  @if($direction == 'down') {
-    border-left: $size solid transparent;
-    border-right: $size solid transparent;
-    border-top: $size solid $color;
-  }
-
-  @if($direction == 'left') {
-    border-bottom: $size solid transparent;  /* left arrow slant */
-	  border-top: $size solid transparent; /* right arrow slant */
-	  border-right: $size solid $color; /* bottom, add background color here */
-  }
-}
+@import '_mixins';
 
 .c-sectors {
   padding: 0 0 75px;

--- a/app/javascript/components/sidebar/styles.scss
+++ b/app/javascript/components/sidebar/styles.scss
@@ -1,26 +1,5 @@
 @import '_settings';
-
-// https://davidwalsh.name/css-triangles
-@mixin triangle($size, $color, $direction) {
-  width: 0;
-  height: 0;
-  font-size: 0;
-	line-height: 0;
-
-  @if($direction == 'right') {
-    border-right: 0;
-    border-bottom: $size solid transparent;  /* left arrow slant */
-    border-top: $size solid transparent; /* right arrow slant */
-    border-left: $size solid $color; /* bottom, add background color here */
-  }
-
-  @if($direction == 'left') {
-    border-left: 0;
-    border-bottom: $size solid transparent;  /* left arrow slant */
-	  border-top: $size solid transparent; /* right arrow slant */
-	  border-right: $size solid $color; /* bottom, add background color here */
-  }
-}
+@import '_mixins';
 
 .c-sidebar {
   z-index: 1;

--- a/app/javascript/components/widget/analysis-result/styles.scss
+++ b/app/javascript/components/widget/analysis-result/styles.scss
@@ -1,19 +1,5 @@
 @import '_settings';
-
-// https://davidwalsh.name/css-triangles
-@mixin triangle($size, $color, $direction) {
-  width: 0;
-  height: 0;
-  font-size: 0;
-	line-height: 0;
-
-  @if($direction == 'left') {
-    border-left: 0;
-    border-bottom: $size solid transparent;  /* left arrow slant */
-	  border-top: $size solid transparent; /* right arrow slant */
-	  border-right: $size solid $color; /* bottom, add background color here */
-  }
-}
+@import '_mixins';
 
 .c-sidebar-analysis-result {
   padding: 0px 30px 20px 55px;

--- a/app/javascript/components/widget/widget-templates/minimun-distance/styles.scss
+++ b/app/javascript/components/widget/widget-templates/minimun-distance/styles.scss
@@ -1,23 +1,10 @@
 @import '_settings';
+@import '_mixins';
 
 @font-face {
   font-family: 'Chalet';
   font-weight: $font-weight-medium;
   src: font-url('/typography/ChaletNewYorkNineteenSixty.ttf') format('truetype');
-}
-
-@mixin arrow($size, $border-width, $color, $direction) {
-  display: inline-block;
-  width: $size;
-  height: $size;
-  border: $border-width solid $color;
-  content: '';
-
-  @if($direction == 'down') {
-    transform: rotate(45deg);
-    border-top: 0;
-    border-left: 0;
-  }
 }
 
 .legend-btn {


### PR DESCRIPTION
## Description of the PR

No space between title and header buttons in data-portal header. Extra padding added

<img width="1074" alt="Screenshot 2020-01-08 at 12 55 07" src="https://user-images.githubusercontent.com/33252015/71984499-428ff500-3229-11ea-9737-8fb4984c4edc.png">

CSS triangle and arrow imported from _mixins.

## Testing instructions

http://localhost:3000/data-portal/COD/2014

## Pivotal Tracker

https://www.pivotaltracker.com/story/show/170598851
