### PR TITLE
Feature/tools

### DIFF
--- a/app/admin/country.rb
+++ b/app/admin/country.rb
@@ -10,9 +10,8 @@ ActiveAdmin.register Country do
   controller do
     def permitted_params
       params.permit country: [:name, :iso, :short_iso, :bbox, :bbox_raw, :background, :has_fsp_maps,
-                              region_ids: [],
-                              partner_ids: [],
-                              links_attributes: [:id, :name, :url, :_destroy]]
+                              :has_finscope, :has_msme, :has_national_diaries, region_ids: [],
+                              partner_ids: [], links_attributes: [:id, :name, :url, :_destroy]]
     end
 
     def scoped_collection
@@ -43,6 +42,9 @@ ActiveAdmin.register Country do
       f.input :bbox_raw, label: 'Bounding box'
       f.input :background, as: :hidden, input_html: { value: f.object.cached_background_data }
       f.input :background, label: 'Background image', as: :file, hint: f.object.background.present? ? image_tag(f.object.background_url(:header)) : content_tag(:span, 'No image yet')
+      f.input :has_finscope, label: 'Has national surveys'
+      f.input :has_msme, label: 'Has MSME'
+      f.input :has_national_diaries, label: 'Has financial diaries'
       f.input :has_fsp_maps, label: 'Has Geospatial data'
 
       f.has_many :links, allow_destroy: true, new_record: true, heading: 'Links' do |link_form|

--- a/app/admin/country.rb
+++ b/app/admin/country.rb
@@ -40,8 +40,10 @@ ActiveAdmin.register Country do
       f.input :iso
       f.input :short_iso
       f.input :bbox_raw, label: 'Bounding box'
+
       f.input :background, as: :hidden, input_html: { value: f.object.cached_background_data }
       f.input :background, label: 'Background image', as: :file, hint: f.object.background.present? ? image_tag(f.object.background_url(:header)) : content_tag(:span, 'No image yet')
+
       f.input :has_finscope, label: 'Has national surveys'
       f.input :has_msme, label: 'Has MSME'
       f.input :has_national_diaries, label: 'Has financial diaries'

--- a/app/admin/region.rb
+++ b/app/admin/region.rb
@@ -43,8 +43,6 @@ ActiveAdmin.register Region do
       f.input :logo, as: :hidden, input_html: { value: f.object.cached_logo_data }
       f.input :logo, as: :file, hint: f.object.logo.present? ? image_tag(f.object.logo_url(:thumb)) : content_tag(:span, 'No image yet')
 
-      f.input :has_fsp_maps, label: 'Has Geospatial data'
-
       f.has_many :links, allow_destroy: true, new_record: true, heading: 'Links' do |link_form|
         link_form.input :name
         link_form.input :url

--- a/app/models/country.rb
+++ b/app/models/country.rb
@@ -26,7 +26,6 @@ class Country < ApplicationRecord
   scope :all_except, ->(country) { where.not(id: country) }
   scope :ordered_by_name, -> { order(:name) }
 
-  attr_accessor :has_finscope
   attr_accessor :has_financial_diaries
   attr_accessor :bbox_raw
 

--- a/db/migrate/20200414153443_add_section_flags_to_countries.rb
+++ b/db/migrate/20200414153443_add_section_flags_to_countries.rb
@@ -1,0 +1,7 @@
+class AddSectionFlagsToCountries < ActiveRecord::Migration[5.2]
+  def change
+    add_column :countries, :has_national_diaries, :boolean, default: false
+    add_column :countries, :has_msme, :boolean, default: false
+    add_column :countries, :has_finscope, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,18 +10,18 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_10_29_114111) do
+ActiveRecord::Schema.define(version: 2020_04_14_153443) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
-  create_table "active_admin_comments", force: :cascade do |t|
+  create_table "active_admin_comments", id: :serial, force: :cascade do |t|
     t.string "namespace"
     t.text "body"
     t.string "resource_id", null: false
     t.string "resource_type", null: false
     t.string "author_type"
-    t.bigint "author_id"
+    t.integer "author_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["author_type", "author_id"], name: "index_active_admin_comments_on_author_type_and_author_id"
@@ -46,13 +46,62 @@ ActiveRecord::Schema.define(version: 2019_10_29_114111) do
     t.index ["reset_password_token"], name: "index_admin_users_on_reset_password_token", unique: true
   end
 
+  create_table "answer_region", id: :serial, force: :cascade do |t|
+    t.integer "row_id", null: false
+    t.string "indicator_id", limit: 255, null: false
+    t.integer "child_indicator_id"
+    t.integer "answer_id"
+    t.string "value", limit: 255
+    t.float "weight", null: false
+    t.string "iso", limit: 255, null: false
+    t.integer "year", null: false
+    t.datetime "createdAt", null: false
+    t.datetime "updatedAt", null: false
+    t.integer "region_4_year_id", null: false
+    t.integer "region4yearId"
+  end
+
+  create_table "answer_regions", force: :cascade do |t|
+    t.integer "row_id", null: false
+    t.string "indicator_id", null: false
+    t.integer "child_indicator_id"
+    t.integer "answer_id"
+    t.string "value"
+    t.float "weight", null: false
+    t.string "iso", null: false
+    t.integer "year", null: false
+    t.bigint "region_4_year_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["region_4_year_id"], name: "index_answer_regions_on_region_4_year_id"
+  end
+
+  create_table "answers", force: :cascade do |t|
+    t.integer "row_id", null: false
+    t.string "indicator_id", null: false
+    t.integer "child_indicator_id"
+    t.integer "answer_id"
+    t.string "value"
+    t.float "weight", null: false
+    t.string "iso", null: false
+    t.integer "year", null: false
+    t.bigint "country_4_year_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["country_4_year_id"], name: "index_answers_on_country_4_year_id"
+    t.index ["indicator_id"], name: "index_answers_on_indicator_id"
+    t.index ["iso"], name: "index_answers_on_iso"
+    t.index ["row_id"], name: "index_answers_on_row_id"
+    t.index ["year"], name: "index_answers_on_year"
+  end
+
   create_table "blogs", id: :serial, force: :cascade do |t|
     t.string "title"
     t.text "summary"
     t.text "content"
     t.string "image_file_name"
     t.string "image_content_type"
-    t.bigint "image_file_size"
+    t.integer "image_file_size"
     t.datetime "image_updated_at"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
@@ -63,8 +112,8 @@ ActiveRecord::Schema.define(version: 2019_10_29_114111) do
     t.string "slug"
     t.boolean "published"
     t.string "custom_author"
-    t.string "record_type", default: "blog"
     t.integer "category_id"
+    t.string "record_type", default: "blog"
     t.boolean "is_featured", default: false
     t.integer "position"
   end
@@ -149,6 +198,11 @@ ActiveRecord::Schema.define(version: 2019_10_29_114111) do
     t.string "short_iso"
     t.boolean "has_fsp_maps", default: false
     t.text "background_data"
+    t.string "map_url"
+    t.text "flag_data"
+    t.boolean "has_national_diaries", default: false
+    t.boolean "has_msme", default: false
+    t.boolean "has_finscope", default: false
   end
 
   create_table "countries_blogs", id: :serial, force: :cascade do |t|
@@ -185,6 +239,28 @@ ActiveRecord::Schema.define(version: 2019_10_29_114111) do
     t.datetime "updated_at", null: false
     t.index ["country_id"], name: "index_countries_news_on_country_id"
     t.index ["news_id"], name: "index_countries_news_on_news_id"
+  end
+
+  create_table "country4years", id: :serial, force: :cascade do |t|
+    t.integer "year"
+    t.float "total_msme"
+    t.float "total"
+    t.string "dataUrl", limit: 255
+    t.datetime "createdAt", null: false
+    t.datetime "updatedAt", null: false
+    t.integer "countryId"
+    t.integer "country_id", null: false
+  end
+
+  create_table "country_4_years", force: :cascade do |t|
+    t.integer "year"
+    t.float "total_msme"
+    t.float "total"
+    t.string "data_url"
+    t.bigint "country_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["country_id"], name: "index_country_4_years_on_country_id"
   end
 
   create_table "country_partners", id: :serial, force: :cascade do |t|
@@ -233,7 +309,7 @@ ActiveRecord::Schema.define(version: 2019_10_29_114111) do
     t.string "name"
     t.string "file_file_name"
     t.string "file_content_type"
-    t.bigint "file_file_size"
+    t.integer "file_file_size"
     t.datetime "file_updated_at"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
@@ -245,7 +321,7 @@ ActiveRecord::Schema.define(version: 2019_10_29_114111) do
     t.text "content"
     t.string "image_file_name"
     t.string "image_content_type"
-    t.bigint "image_file_size"
+    t.integer "image_file_size"
     t.datetime "image_updated_at"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
@@ -255,8 +331,8 @@ ActiveRecord::Schema.define(version: 2019_10_29_114111) do
     t.string "slug"
     t.boolean "published"
     t.string "custom_author"
-    t.string "record_type", default: "event"
     t.integer "category_id"
+    t.string "record_type", default: "event"
     t.boolean "is_featured", default: false
     t.integer "position"
   end
@@ -495,7 +571,7 @@ ActiveRecord::Schema.define(version: 2019_10_29_114111) do
     t.text "summary"
     t.string "image_file_name"
     t.string "image_content_type"
-    t.bigint "image_file_size"
+    t.integer "image_file_size"
     t.datetime "image_updated_at"
     t.datetime "date"
     t.string "url_resource"
@@ -503,8 +579,8 @@ ActiveRecord::Schema.define(version: 2019_10_29_114111) do
     t.string "issuu_link"
     t.string "slug"
     t.boolean "published"
-    t.string "record_type", default: "library"
     t.integer "category_id"
+    t.string "record_type", default: "library"
     t.boolean "is_featured", default: false
     t.integer "position"
     t.text "description"
@@ -558,13 +634,21 @@ ActiveRecord::Schema.define(version: 2019_10_29_114111) do
     t.string "role"
     t.string "image_file_name"
     t.string "image_content_type"
-    t.bigint "image_file_size"
+    t.integer "image_file_size"
     t.datetime "image_updated_at"
     t.string "slug"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.date "date"
     t.integer "order"
+  end
+
+  create_table "mobile_surveys_datasets", force: :cascade do |t|
+    t.integer "year"
+    t.text "iso_code"
+    t.text "filename"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "news", id: :serial, force: :cascade do |t|
@@ -575,15 +659,15 @@ ActiveRecord::Schema.define(version: 2019_10_29_114111) do
     t.text "content"
     t.string "image_file_name"
     t.string "image_content_type"
-    t.bigint "image_file_size"
+    t.integer "image_file_size"
     t.datetime "image_updated_at"
     t.datetime "date"
     t.string "author"
     t.string "issuu_link"
     t.string "slug"
     t.boolean "published"
-    t.string "record_type", default: "news"
     t.integer "category_id"
+    t.string "record_type", default: "news"
     t.boolean "is_featured", default: false
     t.integer "position"
   end
@@ -595,6 +679,46 @@ ActiveRecord::Schema.define(version: 2019_10_29_114111) do
     t.datetime "updated_at", null: false
     t.index ["news_id"], name: "index_news_regions_on_news_id"
     t.index ["region_id"], name: "index_news_regions_on_region_id"
+  end
+
+  create_table "original_answer", id: :serial, force: :cascade do |t|
+    t.jsonb "answer", null: false
+    t.string "iso", limit: 255, null: false
+    t.integer "year", null: false
+    t.datetime "createdAt", null: false
+    t.datetime "updatedAt", null: false
+    t.integer "country4yearId"
+    t.integer "country_4_year_id", null: false
+  end
+
+  create_table "original_answer_region", id: :serial, force: :cascade do |t|
+    t.jsonb "answer", null: false
+    t.string "iso", limit: 255, null: false
+    t.integer "year", null: false
+    t.datetime "createdAt", null: false
+    t.datetime "updatedAt", null: false
+    t.integer "region_4_year_id", null: false
+    t.integer "region4yearId"
+  end
+
+  create_table "original_answer_regions", force: :cascade do |t|
+    t.jsonb "answer", null: false
+    t.string "iso", null: false
+    t.integer "year", null: false
+    t.bigint "region_4_year_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["region_4_year_id"], name: "index_original_answer_regions_on_region_4_year_id"
+  end
+
+  create_table "original_answers", force: :cascade do |t|
+    t.jsonb "answer", null: false
+    t.string "iso", null: false
+    t.integer "year", null: false
+    t.bigint "country_4_year_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["country_4_year_id"], name: "index_original_answers_on_country_4_year_id"
   end
 
   create_table "partners", id: :serial, force: :cascade do |t|
@@ -636,6 +760,26 @@ ActiveRecord::Schema.define(version: 2019_10_29_114111) do
     t.text "custom_text"
   end
 
+  create_table "region4years", id: :serial, force: :cascade do |t|
+    t.integer "year"
+    t.float "total"
+    t.string "dataUrl", limit: 255
+    t.datetime "createdAt", null: false
+    t.datetime "updatedAt", null: false
+    t.integer "regionId"
+    t.integer "region_id", null: false
+  end
+
+  create_table "region_4_years", force: :cascade do |t|
+    t.integer "year"
+    t.float "total"
+    t.string "data_url"
+    t.bigint "region_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["region_id"], name: "index_region_4_years_on_region_id"
+  end
+
   create_table "region_partners", id: :serial, force: :cascade do |t|
     t.integer "region_id"
     t.integer "partner_id"
@@ -654,14 +798,16 @@ ActiveRecord::Schema.define(version: 2019_10_29_114111) do
     t.text "flag_data"
     t.text "logo_data"
     t.text "background_data"
+    t.string "map_url"
     t.index ["slug"], name: "index_regions_on_slug", unique: true
   end
 
-  create_table "sessions", id: :serial, force: :cascade do |t|
+  create_table "sessions", id: false, force: :cascade do |t|
+    t.serial "id", null: false
     t.string "session_id", null: false
     t.text "data"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at"
+    t.datetime "updated_at"
     t.index ["session_id"], name: "index_sessions_on_session_id", unique: true
     t.index ["updated_at"], name: "index_sessions_on_updated_at"
   end
@@ -710,4 +856,14 @@ ActiveRecord::Schema.define(version: 2019_10_29_114111) do
     t.index ["token"], name: "index_users_on_token"
   end
 
+  add_foreign_key "answer_region", "region4years", column: "region4yearId", name: "answer_region_region4yearId_fkey", on_update: :cascade, on_delete: :nullify
+  add_foreign_key "answer_region", "region4years", column: "region_4_year_id", name: "answer_region_region_4_year_id_fkey", on_update: :cascade, on_delete: :cascade
+  add_foreign_key "country4years", "countries", column: "countryId", name: "country4years_countryId_fkey", on_update: :cascade, on_delete: :nullify
+  add_foreign_key "country4years", "countries", name: "country4years_country_id_fkey", on_update: :cascade, on_delete: :cascade
+  add_foreign_key "original_answer", "country4years", column: "country4yearId", name: "original_answer_country4yearId_fkey", on_update: :cascade, on_delete: :nullify
+  add_foreign_key "original_answer", "country4years", column: "country_4_year_id", name: "original_answer_country_4_year_id_fkey", on_update: :cascade, on_delete: :cascade
+  add_foreign_key "original_answer_region", "region4years", column: "region4yearId", name: "original_answer_region_region4yearId_fkey", on_update: :cascade, on_delete: :nullify
+  add_foreign_key "original_answer_region", "region4years", column: "region_4_year_id", name: "original_answer_region_region_4_year_id_fkey", on_update: :cascade, on_delete: :cascade
+  add_foreign_key "region4years", "regions", column: "regionId", name: "region4years_regionId_fkey", on_update: :cascade, on_delete: :nullify
+  add_foreign_key "region4years", "regions", name: "region4years_region_id_fkey", on_update: :cascade, on_delete: :cascade
 end

--- a/lib/tasks/add_section_flags_to_countries.rake
+++ b/lib/tasks/add_section_flags_to_countries.rake
@@ -1,0 +1,29 @@
+namespace :countries do
+  desc 'Set all published to true'
+  task add_section_flags: :environment do
+    user_countries = GetCountriesFromCarto.new.perform
+    user_countries_iso =
+      user_countries ? JSON.parse(user_countries.body)['rows'].collect { |c| c['iso'] } : []
+
+    msme_countries_response = GetMsmeCountriesFromApi.new.perform
+    msme_countries =
+      msme_countries_response ? JSON.parse(msme_countries_response.body).collect { |c| c['iso'] } : []
+
+    @countries_db = Country.ordered_by_name
+    @finscope_countries = Country.finscope_country_list.map { |country_hash| country_hash[:iso] }
+
+    @countries_db.each_with_object([]) do |country, acc|
+      has_finscope = @finscope_countries.include?(country.iso)
+      has_national_diaries = country.financial_diaries.present?
+      has_fsp_maps = country.has_fsp_maps || user_countries_iso.include?(country.iso)
+      has_msme = msme_countries.include?(country.iso)
+
+      country.update_attributes(
+        has_finscope: has_finscope,
+        has_msme: has_msme,
+        has_national_diaries: has_national_diaries,
+        has_fsp_maps: has_fsp_maps
+      )
+    end
+  end
+end

--- a/lib/tasks/add_section_flags_to_countries.rake
+++ b/lib/tasks/add_section_flags_to_countries.rake
@@ -1,5 +1,5 @@
 namespace :countries do
-  desc 'Set all published to true'
+  desc 'Add section flags to countries'
   task add_section_flags: :environment do
     user_countries = GetCountriesFromCarto.new.perform
     user_countries_iso =


### PR DESCRIPTION
This PR contains the code to add the sections flags (tools) for countries. The original idea was to add those values to countries and regions but after checking the code on `data_portal_controller`, region are using the values of the associated country, so it is not necessary.

## Testing instructions

Execute the following tasks to update your database and the values of the section flags

```
bundle exec rake db:migrate
bundle exec rake countries:add_section_flags
```

Then, follow these steps to check that it works properly:

1. Access to countries section on the backoffice
2. Edit the tools of a country
3. Check that the new values have been set on the data portal section.

## Pivotal Tracker

[https://www.pivotaltracker.com/story/show/171875675](https://www.pivotaltracker.com/story/show/171875675)

[https://www.pivotaltracker.com/story/show/171875677](https://www.pivotaltracker.com/story/show/171875677)
