### PR TITLE
Fix/empty categories

### DIFF
--- a/app/assets/javascripts/templates/data_portal/widgets/v3/grouped-bar-mobile.jst.ejs
+++ b/app/assets/javascripts/templates/data_portal/widgets/v3/grouped-bar-mobile.jst.ejs
@@ -7,7 +7,11 @@
       "name": "table",
       "values": <%= data %>,
       "transform": [
-        { "type": "joinaggregate", "as": ["count"] }
+        { "type": "joinaggregate", "as": ["count"] },
+        {
+          "type": "filter", 
+          "expr": "isDefined(datum.category) && isString(datum.category) && datum.category.length > 0"
+        }
       ]
     }
   ],

--- a/app/assets/javascripts/templates/data_portal/widgets/v3/grouped-bar.jst.ejs
+++ b/app/assets/javascripts/templates/data_portal/widgets/v3/grouped-bar.jst.ejs
@@ -7,7 +7,11 @@
       "name": "table",
       "values": <%= data %>,
       "transform": [
-        { "type": "joinaggregate", "as": ["count"] }
+        { "type": "joinaggregate", "as": ["count"] },
+        {
+          "type": "filter", 
+          "expr": "isDefined(datum.category) && isString(datum.category) && datum.category.length > 0"
+        }
       ]
     }
   ],


### PR DESCRIPTION
On mobile surveys we include empty results in the calculation. When generating the vega chart filter out empty categories from visualisation so they dont appear in the widget result.

This affected the land decision widget, but will be adapted to all widgets using the mobile endpoint. 

Pivotal task: 
https://www.pivotaltracker.com/n/projects/1967391/stories/173621452/comments/215792919


You can test it here: 
https://tinyurl.com/ybbdsk85
