### PR TITLE
feat show population change when filters applies

### DIFF
--- a/app/assets/javascripts/models/PopulationModel.js
+++ b/app/assets/javascripts/models/PopulationModel.js
@@ -1,0 +1,50 @@
+(function (App) {
+  'use strict';
+
+  App.Model.PopulationModel = Backbone.Model.extend({
+
+    initialize: function (iso, year, filters) {
+      this.year = year;
+      this.iso = iso;
+      this.population = null;
+      this.filters = filters || null;
+    },
+
+    url: function() {
+      var apiUrl = MOBILE_SURVEYS_API_URL;
+      return apiUrl + '/population?' + this.iso + '=' + this.year + this._serializeFilters();
+    },
+
+    _serializeFilters() {
+      if (this.filters) {
+        var filters = this.filters.map(function (f) {
+          return {
+            indicatorId: f.id,
+            value: f.options
+          }
+        })
+        return '&filters=' + JSON.stringify(filters);
+      } 
+      return '';
+    },
+
+    parse: function (data) {
+      if (data.data && data.data.length) {
+        var populationResponse = data.data[0];
+        var population = populationResponse.map(function (d) {
+          return d.value;
+        }).reduce(function (a, b) {
+          return a + b;
+        });
+
+        return {
+          population: population
+        }
+      }
+      return {
+        population: null
+      }
+    }
+  });
+
+}).call(this, this.App);

--- a/app/assets/javascripts/pages/data_portal/DataPortalMobileSurveysCountryPage.js
+++ b/app/assets/javascripts/pages/data_portal/DataPortalMobileSurveysCountryPage.js
@@ -38,6 +38,8 @@
       this.options = _.extend({}, this.defaults, settings);
       this.indicatorsCollection = new App.Collection.ExploratorySurveyIndicatorsCollection();
       this.countryModel = new App.Model.CountryModel(this.options.iso, this.options.year, false, true);
+      this.populationModel = new App.Model.PopulationModel(this.options.iso, this.options.year);
+
       this.headerContainer = this.el.querySelector('.js-header');
       this.mobileHeaderContainer = this.el.querySelector('.js-mobile-header');
       this.widgetsContainer = this.el.querySelector('.js-widgets');
@@ -176,6 +178,12 @@
      */
     _updateFilters: function (filters) {
       this.options._filters = filters;
+      this.populationModel.filters = this.options._filters;
+      this.populationModel.fetch()
+      .done(function (){
+        this._renderHeader();
+        this._renderMobileHeader();
+      }.bind(this));
     },
 
     /**
@@ -190,12 +198,20 @@
 
       // We need to update the header with the population of the country for the selected year
       this.countryModel.year = year;
+      this.populationModel.year = year;
+
       // If the request fails, we just don't update the population
       this.countryModel.fetch()
         .done(function (){
           this._renderHeader();
           this._renderMobileHeader();
         }.bind(this));
+
+      this.populationModel.fetch()
+      .done(function (){
+        this._renderHeader();
+        this._renderMobileHeader();
+      }.bind(this));
     },
 
     /**
@@ -256,7 +272,8 @@
 
       $.when.apply($, [
         this.indicatorsCollection.fetch(),
-        this.countryModel.fetch()
+        this.countryModel.fetch(),
+        this.populationModel.fetch()
       ])
         .done(function (){
           this._loadingError = false;
@@ -308,7 +325,7 @@
      * @return {string}
      */
     _getReadablePopulation: function () {
-      var population = this.countryModel.get('population');
+      var population = this.populationModel.get('population');
       var factor, unit;
 
       if (!population) return 'No data provided';


### PR DESCRIPTION
**Only mobile surveys for now**

Create new model (**as its an entire new endpoint and logic**) that utilises a new endpoint to get population. Population will update when filters are applied to reflect the correct population used for the charts.

Task: https://www.pivotaltracker.com/story/show/173621403


_If this will be supported on other pages later we can update the model similar to how the country model works._


Testing instructions: 

1. go to: http://localhost:3000/data-portal/exploratory-survey/KEN/2020
2. Make sure population updates when applying filters.